### PR TITLE
Allow base_url to be read from environment variables

### DIFF
--- a/src/pybyd/config.py
+++ b/src/pybyd/config.py
@@ -174,6 +174,7 @@ class BydConfig(BaseModel):
         _ENV_CONFIG_MAP = {
             "BYD_USERNAME": "username",
             "BYD_PASSWORD": "password",
+            "BYD_BASE_URL": "base_url",
             "BYD_COUNTRY_CODE": "country_code",
             "BYD_LANGUAGE": "language",
             "BYD_TIME_ZONE": "time_zone",


### PR DESCRIPTION
This will allow me to run `scripts/dump_all.py` for #3 from my location.

_e.g._ `export BYD_BASE_URL="https://dilinkappoversea-au.byd.auto"`