### PR TITLE
add support for China (CN) region

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,32 @@ asyncio.run(main())
 
 `BydConfig.from_env()` supports `BYD_*` environment variables (including MQTT and control PIN settings).
 
+## China (CN) region
+
+When the server hostname is China (for example `https://dilinksuperappserver-cn.byd.auto`), pyBYD uses the CN stack: WBSK request/response envelopes, `/app/auth/login`, `/app/auth/getAllListByUserId`, a single-shot GPS call to `/vehicleInfo/gps/locationRequestService`, and CN MQTT broker/topic naming (`dynasty_…` client id, `/dynasty/res/…` topics when using Dynasty branding).
+
+Set the base URL and optional CN app headers (see [BYD-re](https://github.com/Niek/BYD-re) for reference values):
+
+```bash
+export BYD_BASE_URL="https://dilinksuperappserver-cn.byd.auto"
+export BYD_USERNAME="13800138000"   # phone-style account id, as in the CN app
+export BYD_PASSWORD="your-password"
+
+# Optional CN-specific overrides (defaults match common CN app builds)
+export BYD_APP_CHANNEL="99"
+export BYD_CN_APP_VERSION="9.10.2"
+export BYD_CN_APP_INNER_VERSION="502"
+export BYD_TARGET_BRAND="1"
+export BYD_VEHICLE_BRAND="1"
+export BYD_NETWORK_OPERATOR="无"
+# export BYD_BRAND_FLAG="dynasty"   # HTTP BrandFlag header (default dynasty)
+
+# If the hostname is ambiguous, force region explicitly:
+# export BYD_REGION=cn
+```
+
+`BYD_TARGET_BRAND` selects which EMQ broker field the client reads (`dynastyEmqBroker`, `oceanEmqBroker`, etc.). Session `identifier` for token envelopes and MQTT uses the brand-specific user id when present, otherwise `superId` (see `Session.effective_api_identifier`).
+
 ## Remote commands
 
 Remote commands require a control PIN (`BydConfig(control_pin=...)` or `command_pwd=...`) and a one-time verification step:
@@ -121,7 +147,7 @@ except BydApiError as e:
 
 ## Scripts
 
-Helper tooling is in [scripts/](scripts/) and generally expects `BYD_USERNAME` / `BYD_PASSWORD`.
+Helper tooling is in [scripts/](scripts/) and generally expects `BYD_USERNAME` / `BYD_PASSWORD`. For CN, set `BYD_BASE_URL` and the `BYD_CN_*` / `BYD_APP_CHANNEL` variables from the section above; dumps and mapping tables then reflect the CN API shape (raw key sets differ from overseas, so compare like with like).
 
 - [scripts/dump_all.py](scripts/dump_all.py): fetch and print endpoint data
 - [scripts/data_diff.py](scripts/data_diff.py): interactive poll-and-diff for changed fields

--- a/dump_and_diff.sh
+++ b/dump_and_diff.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Dumps use whatever BYD_* environment the shell exports (e.g. BYD_BASE_URL for CN vs overseas).
+# Running twice in one session without changing env compares two snapshots from the same backend.
 set -e
 
 file_name=$(date +dump-%Y_%m_%d-%H_%M_%S.json)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ version-file = "src/pybyd/_version.py"
 [tool.hatch.build]
 artifacts = [
     "src/pybyd/data/bangcle_tables.bin",
+    "src/pybyd/data/wbsk_tables.json",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/scripts/data_diff.py
+++ b/scripts/data_diff.py
@@ -19,6 +19,16 @@ Options::
     --settle SECS        Seconds to wait after Enter before polling (default: 2)
     --baseline-delay S   Delay between noise-calibration snapshots (default: 4)
     --verbose / -v       Enable debug logging
+
+China (CN) example::
+
+    export BYD_BASE_URL="https://dilinksuperappserver-cn.byd.auto"
+    export BYD_USERNAME="13800138000"
+    export BYD_PASSWORD="your-password"
+    export BYD_APP_CHANNEL="99"
+    export BYD_CN_APP_INNER_VERSION="502"
+    export BYD_TARGET_BRAND="1"
+    python scripts/data_diff.py
 """
 
 from __future__ import annotations

--- a/scripts/dump_all.py
+++ b/scripts/dump_all.py
@@ -24,6 +24,19 @@ Options::
     --skip-hvac          Skip HVAC status endpoint
     --skip-realtime      Skip realtime endpoint
     --skip-latest-config Skip latest capability-config endpoint
+
+China (CN) example::
+
+    export BYD_BASE_URL="https://dilinksuperappserver-cn.byd.auto"
+    export BYD_USERNAME="13800138000"
+    export BYD_PASSWORD="your-password"
+    export BYD_APP_CHANNEL="99"
+    export BYD_CN_APP_VERSION="9.10.2"
+    export BYD_CN_APP_INNER_VERSION="502"
+    export BYD_TARGET_BRAND="1"
+    python scripts/dump_all.py --json --output dump-cn.json
+
+Text and JSON output include ``region`` (``cn`` / ``overseas``) and ``base_url`` so dumps are self-describing.
 """
 
 from __future__ import annotations
@@ -248,8 +261,11 @@ async def main() -> None:
         skip.add("latest_config")
 
     config = BydConfig.from_env()
+    region = "cn" if config.is_china_region else "overseas"
     result: dict[str, Any] = {
         "timestamp": datetime.now(UTC).isoformat(),
+        "region": region,
+        "base_url": str(config.base_url),
         "app_version": config.app_version,
         "app_inner_version": config.app_inner_version,
         "vehicles": [],
@@ -258,6 +274,8 @@ async def main() -> None:
     out: list[str] = []
     out.append(_section("pybyd dump_all"))
     out.append(f"  time      : {result['timestamp']}")
+    out.append(f"  region    : {region}")
+    out.append(f"  base_url  : {config.base_url}")
     out.append(f"  app_ver   : {config.app_version} (inner {config.app_inner_version})")
 
     async with BydClient(config) as client:

--- a/scripts/generate_api_mapping_tables.py
+++ b/scripts/generate_api_mapping_tables.py
@@ -13,6 +13,9 @@ Each table contains:
 - Raw current value
 - Parsed in pyBYD
 
+**Region:** Raw key sets differ between China (CN) and overseas backends. A snapshot taken with
+``BYD_BASE_URL`` pointing at a CN host is not directly comparable to one from an EU/overseas host.
+
 For enum-mapped fields, the parsed column includes:
 - current mapping (``raw -> Enum.Member``)
 - all enum possibilities (one per line via ``<br>``)
@@ -30,6 +33,15 @@ Options::
     --vin LNBX...       Target specific VIN (default: first account vehicle)
     --output FILE       Write markdown to FILE instead of stdout
     --skip-push         Skip push notification endpoint
+
+China (CN) example::
+
+    export BYD_BASE_URL="https://dilinksuperappserver-cn.byd.auto"
+    export BYD_USERNAME="13800138000"
+    export BYD_PASSWORD="your-password"
+    export BYD_CN_APP_INNER_VERSION="502"
+    export BYD_TARGET_BRAND="1"
+    python scripts/generate_api_mapping_tables.py --output api-mapping-cn.md
 """
 
 from __future__ import annotations
@@ -446,6 +458,7 @@ async def _generate_markdown(vin: str | None, *, include_push: bool) -> str:
     """Poll endpoints and return markdown report text."""
     config = BydConfig.from_env()
     now_iso = datetime.now(UTC).isoformat()
+    region = "cn" if config.is_china_region else "overseas"
     lines: list[str] = [
         "# pyBYD live API mapping snapshot",
         "",
@@ -454,6 +467,9 @@ async def _generate_markdown(vin: str | None, *, include_push: bool) -> str:
         "- Optional: `python scripts/generate_api_mapping_tables.py --vin YOUR_VIN --skip-push`",
         "",
         f"Generated: {now_iso}",
+        f"Region: {region}",
+        f"Base URL: {config.base_url}",
+        "",
     ]
 
     async with BydClient(config) as client:

--- a/src/pybyd/_api/_common.py
+++ b/src/pybyd/_api/_common.py
@@ -18,6 +18,7 @@ import time
 from typing import Any
 
 from pybyd._api._envelope import build_token_outer_envelope
+from pybyd._api.cn_envelope import build_cn_inner_base, build_cn_token_outer_envelope
 from pybyd._constants import SESSION_EXPIRED_CODES
 from pybyd._crypto.aes import aes_decrypt_utf8
 from pybyd._transport import Transport
@@ -43,6 +44,9 @@ def build_inner_base(
     request_serial: str | None = None,
 ) -> dict[str, str]:
     """Build common inner payload fields used by most BYD endpoints."""
+    if config.is_china_region:
+        return build_cn_inner_base(config, now_ms=now_ms, vin=vin, request_serial=request_serial)
+
     if now_ms is None:
         now_ms = int(time.time() * 1000)
 
@@ -154,7 +158,14 @@ async def post_token_json(
     if now_ms is None:
         now_ms = int(time.time() * 1000)
 
-    outer, content_key = build_token_outer_envelope(config, session, inner, now_ms, user_type=user_type)
+    if config.is_china_region:
+        outer, content_key = build_cn_token_outer_envelope(
+            config, session, inner, now_ms, user_type=user_type
+        )
+    else:
+        outer, content_key = build_token_outer_envelope(
+            config, session, inner, now_ms, user_type=user_type
+        )
 
     response = await transport.post_secure(endpoint, outer)
     code = str(response.get("code", ""))

--- a/src/pybyd/_api/cn_envelope.py
+++ b/src/pybyd/_api/cn_envelope.py
@@ -1,0 +1,123 @@
+"""China (CN) token-authenticated outer envelope and inner base payloads."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+from typing import Any
+
+from pybyd._crypto.aes import aes_encrypt_hex
+from pybyd._crypto.hashing import compute_cn_checkcode_payload, sha1_mixed
+from pybyd._crypto.signing import build_cn_sign_string
+from pybyd.config import BydConfig
+from pybyd.session import Session
+
+
+def build_cn_inner_base(
+    config: BydConfig,
+    *,
+    now_ms: int | None = None,
+    vin: str | None = None,
+    request_serial: str | None = None,
+) -> dict[str, str]:
+    """Common inner fields for CN post-login requests (``buildInner`` in BYD-re ``client.js``)."""
+    if now_ms is None:
+        now_ms = int(time.time() * 1000)
+
+    inner: dict[str, str] = {
+        "deviceName": f"{config.device.mobile_brand}{config.device.mobile_model}",
+        "deviceType": config.device.device_type,
+        "imeiMD5": config.device.imei_md5,
+        "mobileBrand": config.device.mobile_brand,
+        "mobileModel": config.device.mobile_model,
+        "networkOperator": config.network_operator,
+        "networkType": config.device.network_type,
+        "osType": "Android",
+        "osVersion": config.device.os_version,
+        "random": secrets.token_hex(16).upper(),
+        "softType": config.soft_type,
+        "timeStamp": str(now_ms),
+        "version": config.cn_app_inner_version,
+    }
+    if vin:
+        inner["vin"] = str(vin)
+    if request_serial:
+        inner["requestSerial"] = str(request_serial)
+    return inner
+
+
+def build_cn_vehicle_list_inner(
+    config: BydConfig,
+    *,
+    now_ms: int | None = None,
+) -> dict[str, str]:
+    """Vehicle list inner payload (includes ``appUiName``)."""
+    inner = build_cn_inner_base(config, now_ms=now_ms)
+    inner["appUiName"] = ""
+    return inner
+
+
+def build_cn_token_outer_envelope(
+    config: BydConfig,
+    session: Session,
+    inner: dict[str, str],
+    now_ms: int,
+    *,
+    user_type: str | None = None,
+) -> tuple[dict[str, Any], str]:
+    """CN signed outer envelope for post-login requests (WBSK layer applied by transport)."""
+    _ = user_type  # reserved for parity with overseas envelope; CN uses identifierType instead
+    req_timestamp = str(now_ms)
+    content_key = session.content_key()
+    sign_key = session.sign_key()
+    api_id = session.effective_api_identifier
+
+    encry_data = aes_encrypt_hex(
+        json.dumps(inner, separators=(",", ":")),
+        content_key,
+    )
+
+    id_type = 0 if inner.get("vin") else 2
+    sign_fields: dict[str, Any] = {
+        **inner,
+        "appChannel": config.app_channel,
+        "identifier": api_id,
+        "identifierType": id_type,
+        "imeiMD5": config.device.imei_md5,
+        "reqTimestamp": req_timestamp,
+        "targetBrand": config.target_brand,
+        "vehicleBrand": config.vehicle_brand,
+    }
+    if inner.get("vin"):
+        sign_fields["objective"] = inner["vin"]
+
+    sign = sha1_mixed(build_cn_sign_string(sign_fields, sign_key))
+
+    outer: dict[str, Any] = {
+        "appChannel": config.app_channel,
+        "encryData": encry_data,
+        "identifier": api_id,
+        "identifierType": id_type,
+        "imeiMD5": config.device.imei_md5,
+        "objective": inner.get("vin"),
+        "outModelTypes": None,
+        "reqTimestamp": req_timestamp,
+        "sign": sign,
+        "softType": None,
+        "targetBrand": config.target_brand,
+        "vehicleBrand": config.vehicle_brand,
+        "version": None,
+    }
+
+    outer["ostype"] = config.device.ostype
+    outer["imei"] = config.device.imei
+    outer["mac"] = config.device.mac
+    outer["model"] = config.device.model
+    outer["sdk"] = config.device.sdk
+    outer["mod"] = config.device.mod
+    outer["serviceTime"] = str(int(time.time() * 1000))
+
+    outer["checkcode"] = compute_cn_checkcode_payload({k: v for k, v in outer.items() if k != "checkcode"})
+
+    return outer, content_key

--- a/src/pybyd/_api/login.py
+++ b/src/pybyd/_api/login.py
@@ -160,5 +160,6 @@ def parse_login_response(
         user_id=str(token["userId"]),
         sign_token=str(token["signToken"]),
         encry_token=str(token["encryToken"]),
+        super_id=None,
         raw=token,
     )

--- a/src/pybyd/_api/login_cn.py
+++ b/src/pybyd/_api/login_cn.py
@@ -1,0 +1,153 @@
+"""China (CN) login endpoint.
+
+Endpoint:
+  - /app/auth/login
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import time
+from typing import Any
+
+from pybyd._crypto.aes import aes_decrypt_utf8, aes_encrypt_hex
+from pybyd._crypto.hashing import compute_cn_checkcode_payload, md5_hex, pwd_login_key, sha1_mixed
+from pybyd._crypto.signing import build_cn_sign_string
+from pybyd.config import BydConfig
+from pybyd.exceptions import BydAuthenticationError
+from pybyd.models.token import AuthToken
+
+_logger = logging.getLogger(__name__)
+
+_CN_LOGIN_ENDPOINT = "/app/auth/login"
+
+
+def build_cn_login_request(config: BydConfig, now_ms: int) -> dict[str, Any]:
+    """Build the outer payload for CN login (before device fields + checkcode + WBSK)."""
+    random_hex = secrets.token_hex(16).upper()
+    req_timestamp = str(now_ms)
+
+    inner: dict[str, str] = {
+        "appInnerVersion": config.cn_app_inner_version,
+        "appVersion": config.cn_app_version,
+        "bluetoothMac": "",
+        "city": "",
+        "configVersion": "10000",
+        "deviceType": config.device.device_type,
+        "devicename": f"{config.device.mobile_brand}{config.device.mobile_model}",
+        "imeiMD5": config.device.imei_md5,
+        "isAuto": "0",
+        "latitude": "",
+        "longitude": "",
+        "mobileBrand": config.device.mobile_brand,
+        "mobileModel": config.device.mobile_model,
+        "networkOperator": config.network_operator,
+        "networkType": config.device.network_type,
+        "osType": "Android",
+        "osVersion": config.device.os_type,
+        "random": random_hex,
+        "softType": config.soft_type,
+        "timeStamp": req_timestamp,
+    }
+
+    encry_data = aes_encrypt_hex(
+        json.dumps(inner, separators=(",", ":")),
+        pwd_login_key(config.password),
+    )
+
+    sign_fields: dict[str, Any] = {
+        **inner,
+        "appChannel": config.app_channel,
+        "identifier": config.username,
+        "loginType": 0,
+        "reqTimestamp": req_timestamp,
+        "targetBrand": config.target_brand,
+    }
+    sign = sha1_mixed(build_cn_sign_string(sign_fields, md5_hex(config.password)))
+
+    outer: dict[str, Any] = {
+        "appChannel": config.app_channel,
+        "encryData": encry_data,
+        "identifier": config.username,
+        "imeiMD5": config.device.imei_md5,
+        "isAuto": "0",
+        "loginType": 0,
+        "reqTimestamp": req_timestamp,
+        "sign": sign,
+        "targetBrand": config.target_brand,
+    }
+
+    outer["ostype"] = config.device.ostype
+    outer["imei"] = config.device.imei
+    outer["mac"] = config.device.mac
+    outer["model"] = config.device.model
+    outer["sdk"] = config.device.sdk
+    outer["mod"] = config.device.mod
+    outer["serviceTime"] = str(int(time.time() * 1000))
+    outer["checkcode"] = compute_cn_checkcode_payload(
+        {k: v for k, v in outer.items() if k != "checkcode"}
+    )
+
+    return outer
+
+
+def parse_cn_login_response(
+    outer_response: dict[str, Any],
+    password: str,
+    *,
+    target_brand: str,
+) -> AuthToken:
+    """Parse CN login response."""
+    if str(outer_response.get("code")) != "0":
+        raise BydAuthenticationError(
+            f"Login failed: code={outer_response.get('code')} message={outer_response.get('message', '')}",
+            code=str(outer_response.get("code", "")),
+            endpoint=_CN_LOGIN_ENDPOINT,
+        )
+
+    respond_data = outer_response.get("respondData")
+    if not respond_data:
+        raise BydAuthenticationError(
+            "Login response missing respondData",
+            endpoint=_CN_LOGIN_ENDPOINT,
+        )
+
+    plaintext = aes_decrypt_utf8(respond_data, pwd_login_key(password))
+    inner = json.loads(plaintext)
+    _logger.debug("HTTP decoded endpoint=%s plaintext=%s", _CN_LOGIN_ENDPOINT, plaintext)
+    token = inner.get("token") if isinstance(inner, dict) else None
+
+    if not isinstance(token, dict):
+        raise BydAuthenticationError(
+            "Login response missing token",
+            endpoint=_CN_LOGIN_ENDPOINT,
+        )
+
+    sign_token = str(token.get("signToken") or "")
+    encry_token = str(token.get("encryToken") or token.get("encryptToken") or "")
+
+    super_id = str(token.get("superId") or "")
+    brand_user_id = ""
+    rel = token.get("superBindRelationDtoMap")
+    if isinstance(rel, dict) and target_brand in rel:
+        entry = rel[target_brand]
+        if isinstance(entry, dict) and entry.get("userId") is not None:
+            brand_user_id = str(entry["userId"])
+
+    user_id = brand_user_id if brand_user_id else super_id
+
+    if not user_id or not sign_token or not encry_token:
+        raise BydAuthenticationError(
+            "Login response missing token fields",
+            endpoint=_CN_LOGIN_ENDPOINT,
+        )
+
+    return AuthToken(
+        user_id=user_id,
+        sign_token=sign_token,
+        encry_token=encry_token,
+        super_id=super_id if super_id else None,
+        raw=token,
+    )

--- a/src/pybyd/_api/vehicle.py
+++ b/src/pybyd/_api/vehicle.py
@@ -1,18 +1,33 @@
 """Vehicle list endpoint.
 
-Endpoint:
-  - /app/account/getAllListByUserId
+Endpoints:
+  - /app/account/getAllListByUserId (overseas)
+  - /app/auth/getAllListByUserId (CN)
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from pybyd._api._common import build_inner_base, post_token_json
+from pybyd._api.cn_envelope import build_cn_vehicle_list_inner
 from pybyd._transport import Transport
 from pybyd.config import BydConfig
 from pybyd.models.vehicle import Vehicle
 from pybyd.session import Session
 
-_ENDPOINT = "/app/account/getAllListByUserId"
+_ENDPOINT_OVERSEAS = "/app/account/getAllListByUserId"
+_ENDPOINT_CN = "/app/auth/getAllListByUserId"
+
+
+def _vehicle_list_items(decoded: Any) -> list[Any]:
+    if isinstance(decoded, list):
+        return decoded
+    if isinstance(decoded, dict):
+        nested = decoded.get("diLinkAutoInfoList")
+        if isinstance(nested, list):
+            return nested
+    return []
 
 
 async def fetch_vehicle_list(
@@ -21,13 +36,18 @@ async def fetch_vehicle_list(
     transport: Transport,
 ) -> list[Vehicle]:
     """Fetch all vehicles associated with the authenticated user."""
-    inner = build_inner_base(config)
+    if config.is_china_region:
+        inner = build_cn_vehicle_list_inner(config)
+        endpoint = _ENDPOINT_CN
+    else:
+        inner = build_inner_base(config)
+        endpoint = _ENDPOINT_OVERSEAS
     decoded = await post_token_json(
-        endpoint=_ENDPOINT,
+        endpoint=endpoint,
         config=config,
         session=session,
         transport=transport,
         inner=inner,
     )
-    items = decoded if isinstance(decoded, list) else []
-    return [Vehicle.model_validate(item) for item in items]
+    items = _vehicle_list_items(decoded)
+    return [Vehicle.model_validate(item) for item in items if isinstance(item, dict)]

--- a/src/pybyd/_crypto/hashing.py
+++ b/src/pybyd/_crypto/hashing.py
@@ -43,3 +43,14 @@ def compute_checkcode(payload: dict[str, Any]) -> str:
     json_str = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
     md5 = hashlib.md5(json_str.encode("utf-8")).hexdigest()
     return md5[24:32] + md5[8:16] + md5[16:24] + md5[0:8]
+
+
+def compute_cn_checkcode_json(json_str: str) -> str:
+    """China app outer payload checkcode: SHA-256 hex of the JSON string (no checkcode field yet)."""
+    return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
+
+
+def compute_cn_checkcode_payload(payload: dict[str, Any]) -> str:
+    """SHA-256 checkcode from ``json.dumps`` of *payload* (must not include ``checkcode``)."""
+    json_str = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    return compute_cn_checkcode_json(json_str)

--- a/src/pybyd/_crypto/signing.py
+++ b/src/pybyd/_crypto/signing.py
@@ -2,9 +2,25 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 
 def build_sign_string(fields: dict[str, str], password: str) -> str:
     """Build the sign string by sorting fields and appending password."""
     keys = sorted(fields.keys())
     joined = "&".join(f"{key}={'null' if fields[key] is None else fields[key]}" for key in keys)
+    return f"{joined}&password={password}"
+
+
+def _cn_sign_value(value: Any) -> str:
+    """Stringify a sign-field value like JavaScript ``String(x)`` (``null`` → ``\"null\"``)."""
+    if value is None:
+        return "null"
+    return str(value)
+
+
+def build_cn_sign_string(fields: dict[str, Any], password: str) -> str:
+    """CN signing: sorted keys, values coerced with JS-style ``String``."""
+    keys = sorted(fields.keys())
+    joined = "&".join(f"{key}={_cn_sign_value(fields[key])}" for key in keys)
     return f"{joined}&password={password}"

--- a/src/pybyd/_crypto/wbsk.py
+++ b/src/pybyd/_crypto/wbsk.py
@@ -1,0 +1,450 @@
+"""WBSK white-box AES-256 envelope (China BYD app transport layer).
+
+Port of BYD-re ``wbsk.js``; tables from ``data/wbsk_tables.json``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import importlib.resources
+import json
+import struct
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pybyd.exceptions import BydCryptoError
+
+NIBBLE_ENCODE = [0x0, 0x8, 0x4, 0xC, 0x1, 0x9, 0x5, 0xD, 0x2, 0xA, 0x6, 0xE, 0x3, 0xB, 0x7, 0xF]
+NIBBLE_DECODE = [0x0, 0x4, 0x8, 0xC, 0x2, 0x6, 0xA, 0xE, 0x1, 0x5, 0x9, 0xD, 0x3, 0x7, 0xB, 0xF]
+
+MYSTERY_ENCODE: list[int] = [NIBBLE_ENCODE[NIBBLE_ENCODE[n ^ 8]] for n in range(16)]
+
+WBSK_KEYS: dict[str, str] = {
+    "outerEncryptKey": (
+        "4dca015d9f0488cdea45e890de3b9c4d16c9f82e1082e295c8312d34da7214b805bdec33d8473ab04c84a51eebee4fd5efee21ed403a159a083dbb2854c92719d8f24dd3002ce675c4b930fd5f410ebe56d9594532f9c109b7f2dc58eebd83a83cc948fd3dc0b696add8b06d19efa7c8c04d17f60d144d943e21ef4add5af566ef14241de9c3bb03cf9b9d3c5d042caa1fcdf222e02ba7cf577cc70375d0b4e7e3340278e56ddee1a180451b3a04f25fe34f0d1f05ec426b0de801e7d7382ecf2c3ab7be923c2d5ff0c33eaa4c45c71b258045f68bd7ad0f594ff86785611f67f30da78dfa9b427f04d625a2c61e2db62e1fe7d4"
+    ),
+    "outerDecryptKey": (
+        "72ca0163b22e2973656a67ac1ae1490a61133824a0cd235bcfcd6032dba79d3ca51b1c4d1b03068566ff084645dcc9e6e8a28b39c71e72dec3fe4074109a84f5564d3f43f4854fb634bf633dabe218a5b73470dff70b07161b76c74d92bffa15bcb7fa4fc448a0fe83b62c9dd97f36d1d1d7613028041bb1dd328397bbf8c8bf6f81321f5e2d4982761a375bded52a1de198169839fabad771bc677b57f806c1ca385f43627e9a5081c43d7c9d9fa86e7e78cc0a8050a2420a76c842abbe93eb38f2487bdf93087cd24097a16539da2f86feb693432daf8f0618cbf97ffea3a762b7b91050f8634a8d3ceb25ea7d2b3264a77337"
+    ),
+    "innerEncryptKey": (
+        "9fca018f72712b15e23c275ea5e06a92d8b98404cf0bf960955596ff47dd2adf8f9e0c3ca1363e8be88cb6fced211933e5c3484c20c7bc3ae1eb8541027fef4a20b2f302d93582f7f4349fef05c16d389956ae9f2a7aea278fd5232229e38caca017ffbaf5138d2cadbca917b4694fb2882a64809c095387b7353608ca3a17913e5863770465986995c684ea7db01e0c35c69fd169a8e14ec5123beb5b8dad6e1c5198f34ed1c44d5f9b15035673df5953e5e42351f58052c1483fa4cf93c646a396081355a46d5a7e0ce30d54049802829cd78c1a77c7db8f74acb244b73c5147f161ee25bd702112cec97c339a6b3314527d12"
+    ),
+    "innerDecryptKey": (
+        "71ca0160b689febe1c11e07bc8f8cec81decf71b6c3e0be299a35211888c2fb177958e57a6e971d0a874ecb50991786faf3a34b178f13a668bd14b81a82d3f799f6f0c8bd002406c8b6fdd54b3bb30c0c7d27c906dba87decde28717a0874abacf41755646b4a2c06854615ab00ae53136cbea3302b047659e7a42f792a7369fc130d8ffdc114a7a2cf2fa669b9b337905ff58fe3cc40b9b1edf37ebe50d36b3416abbd32837895b8ea1f22b9eab35efd791d9153208630297b8b953a9ca33265854c33959979b9eb1d049326986851170f4b51d151f43a30c6298a8c03503477336b2000c49746181ca30eabded6d3088b7f615"
+    ),
+    "outerEncryptIv": "91339992399838993130933138923692",
+    "outerDecryptIv": "54cc5558c551c155c4c05cc4c158ca58",
+    "innerEncryptIv": "a8bb9ab895ba95363a81b1949da68184",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedWbcKey:
+    key_data: bytes
+    key_size_bits: int
+    num_rounds: int
+    is_decrypt: int
+    block_size: int
+    mode: int
+
+
+def _decode_byte_table(encoded: dict[str, str], name: str) -> bytes:
+    b64 = encoded.get(name)
+    if not isinstance(b64, str) or not b64:
+        raise BydCryptoError(f"Missing embedded WBSK table: {name}")
+    buf = base64.b64decode(b64)
+    if len(buf) != 256:
+        raise BydCryptoError(f"WBSK table {name} has unexpected size {len(buf)} (expected 256)")
+    return buf
+
+
+def _decode_u32_table(encoded: dict[str, str], name: str) -> list[int]:
+    b64 = encoded.get(name)
+    if not isinstance(b64, str) or not b64:
+        raise BydCryptoError(f"Missing embedded WBSK table: {name}")
+    buf = base64.b64decode(b64)
+    if len(buf) != 1024:
+        raise BydCryptoError(f"WBSK table {name} has unexpected size {len(buf)} (expected 1024)")
+    return [struct.unpack_from("<I", buf, i * 4)[0] for i in range(256)]
+
+
+def _load_wbsk_tables_json() -> dict[str, str]:
+    try:
+        ref = importlib.resources.files("pybyd").joinpath("data/wbsk_tables.json")
+        raw = ref.read_bytes()
+    except FileNotFoundError as exc:
+        raise BydCryptoError(
+            "wbsk_tables.json not found in pybyd package data. "
+            "Reinstall/upgrade pybyd so wheel data files are included."
+        ) from exc
+    data = json.loads(raw.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise BydCryptoError("wbsk_tables.json must contain a JSON object")
+    return {str(k): str(v) for k, v in data.items()}
+
+
+class WbskTables:
+    """Loaded WBSK lookup tables (singleton per process)."""
+
+    _instance: ClassVar[WbskTables | None] = None
+
+    def __init__(self, encoded: dict[str, str]) -> None:
+        self.enc_init_xor = _decode_byte_table(encoded, "encInitXor")
+        self.enc_round_xor = _decode_byte_table(encoded, "encRoundXor")
+        self.enc_sbox = _decode_byte_table(encoded, "encSbox")
+        self.enc_final_xor = _decode_byte_table(encoded, "encFinalXor")
+        self.enc_te0 = _decode_u32_table(encoded, "encTe0")
+        self.enc_te1 = _decode_u32_table(encoded, "encTe1")
+        self.enc_te2 = _decode_u32_table(encoded, "encTe2")
+        self.enc_te3 = _decode_u32_table(encoded, "encTe3")
+        self.dec_init_xor = _decode_byte_table(encoded, "decInitXor")
+        self.dec_round_xor = _decode_byte_table(encoded, "decRoundXor")
+        self.dec_inv_sbox = _decode_byte_table(encoded, "decInvSbox")
+        self.dec_final_xor = _decode_byte_table(encoded, "decFinalXor")
+        self.dec_td0 = _decode_u32_table(encoded, "decTd0")
+        self.dec_td1 = _decode_u32_table(encoded, "decTd1")
+        self.dec_td2 = _decode_u32_table(encoded, "decTd2")
+        self.dec_td3 = _decode_u32_table(encoded, "decTd3")
+
+    @classmethod
+    def get(cls) -> WbskTables:
+        if cls._instance is None:
+            cls._instance = cls(_load_wbsk_tables_json())
+        return cls._instance
+
+
+def prot_xor(table: bytes, a: int, b: int) -> int:
+    hi = table[((a >> 4) << 4) ^ (b >> 4)] & 0xF0
+    lo = (table[((a & 0xF) << 4) ^ (b & 0xF)] >> 4) & 0x0F
+    return hi | lo
+
+
+def parse_wbc_key(hex_str: str) -> ParsedWbcKey:
+    raw = bytes.fromhex(hex_str)
+    if len(raw) < 5:
+        raise BydCryptoError(f"WBC key blob too short: {len(raw)} bytes")
+    mode = raw[0] ^ raw[3]
+    key_data = bytearray(len(raw) - 4)
+    for i in range(4, len(raw)):
+        key_data[i - 4] = raw[i] ^ raw[i % 3]
+    key_data_b = bytes(key_data)
+
+    key_size_bits: int
+    if mode in (0, 1):
+        key_size_bits = 0x80
+    elif mode in (2, 3):
+        key_size_bits = 0xC0
+    elif mode in (4, 5):
+        key_size_bits = 0x80
+    elif mode in (6, 7):
+        key_size_bits = 0x40
+    elif mode in (8, 9):
+        key_size_bits = 0xC0
+    elif mode in (0xA, 0xB):
+        key_size_bits = 0x80
+    elif mode in (0xC, 0xD):
+        key_size_bits = 0x80
+    elif mode in (0xE, 0xF):
+        key_size_bits = 0xC0
+    elif mode in (0x10, 0x11):
+        key_size_bits = 0x100
+    elif mode in (0x12, 0x13):
+        key_size_bits = 0x40
+    elif mode in (0x14, 0x15):
+        key_size_bits = 0xC0
+    elif mode in (0x16, 0x17):
+        key_size_bits = 0x80
+    else:
+        raise BydCryptoError(f"Unknown WBC mode: 0x{mode:x}")
+
+    num_rounds = (key_size_bits >> 5) + 6
+    is_decrypt = mode & 1
+    block_size = 8 if mode in (6, 7, 0x12, 0x13) else 16
+    return ParsedWbcKey(
+        key_data=key_data_b,
+        key_size_bits=key_size_bits,
+        num_rounds=num_rounds,
+        is_decrypt=is_decrypt,
+        block_size=block_size,
+        mode=mode,
+    )
+
+
+def wbc_encrypt_block(t: WbskTables, inp: bytes, key_data: bytes, num_rounds: int) -> bytes:
+    state = bytearray(16)
+    temp1 = bytearray(16)
+    temp2 = bytearray(16)
+    for i in range(16):
+        state[i] = prot_xor(t.enc_init_xor, inp[i], key_data[i])
+
+    te1i = [5, 9, 13, 1]
+    te2i = [10, 14, 2, 6]
+    te3i = [15, 3, 7, 11]
+    for r in range(1, num_rounds):
+        for c in range(4):
+            v = t.enc_te0[state[c * 4]]
+            temp1[c * 4] = (v >> 24) & 0xFF
+            temp1[c * 4 + 1] = (v >> 16) & 0xFF
+            temp1[c * 4 + 2] = (v >> 8) & 0xFF
+            temp1[c * 4 + 3] = v & 0xFF
+        for c in range(4):
+            v = t.enc_te1[state[te1i[c]]]
+            temp2[c * 4] = (v >> 24) & 0xFF
+            temp2[c * 4 + 1] = (v >> 16) & 0xFF
+            temp2[c * 4 + 2] = (v >> 8) & 0xFF
+            temp2[c * 4 + 3] = v & 0xFF
+        for i in range(16):
+            temp1[i] = prot_xor(t.enc_round_xor, temp1[i], temp2[i])
+        for c in range(4):
+            v = t.enc_te2[state[te2i[c]]]
+            temp2[c * 4] = (v >> 24) & 0xFF
+            temp2[c * 4 + 1] = (v >> 16) & 0xFF
+            temp2[c * 4 + 2] = (v >> 8) & 0xFF
+            temp2[c * 4 + 3] = v & 0xFF
+        for i in range(16):
+            temp1[i] = prot_xor(t.enc_round_xor, temp1[i], temp2[i])
+        for c in range(4):
+            v = t.enc_te3[state[te3i[c]]]
+            temp2[c * 4] = (v >> 24) & 0xFF
+            temp2[c * 4 + 1] = (v >> 16) & 0xFF
+            temp2[c * 4 + 2] = (v >> 8) & 0xFF
+            temp2[c * 4 + 3] = v & 0xFF
+        for i in range(16):
+            temp1[i] = prot_xor(t.enc_round_xor, temp1[i], temp2[i])
+        rk_off = r * 16
+        for i in range(16):
+            state[i] = prot_xor(t.enc_round_xor, temp1[i], key_data[rk_off + i])
+
+    sr = [0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12, 1, 6, 11]
+    for i in range(16):
+        temp1[i] = t.enc_sbox[state[sr[i]]]
+    output = bytearray(16)
+    frk_off = num_rounds * 16
+    for i in range(16):
+        output[i] = prot_xor(t.enc_final_xor, temp1[i], key_data[frk_off + i])
+    return bytes(output)
+
+
+def wbc_decrypt_block(t: WbskTables, inp: bytes, key_data: bytes, num_rounds: int) -> bytes:
+    state = bytearray(16)
+    temp1 = bytearray(16)
+    temp2 = bytearray(16)
+    for i in range(16):
+        state[i] = prot_xor(t.dec_init_xor, inp[i], key_data[i])
+
+    td1i = [13, 1, 5, 9]
+    td2i = [10, 14, 2, 6]
+    td3i = [7, 11, 15, 3]
+    for r in range(1, num_rounds):
+        for c in range(4):
+            v = t.dec_td0[state[c * 4]]
+            temp1[c * 4] = (v >> 24) & 0xFF
+            temp1[c * 4 + 1] = (v >> 16) & 0xFF
+            temp1[c * 4 + 2] = (v >> 8) & 0xFF
+            temp1[c * 4 + 3] = v & 0xFF
+        for c in range(4):
+            v = t.dec_td1[state[td1i[c]]]
+            temp2[c * 4] = (v >> 24) & 0xFF
+            temp2[c * 4 + 1] = (v >> 16) & 0xFF
+            temp2[c * 4 + 2] = (v >> 8) & 0xFF
+            temp2[c * 4 + 3] = v & 0xFF
+        for i in range(16):
+            temp1[i] = prot_xor(t.dec_round_xor, temp1[i], temp2[i])
+        for c in range(4):
+            v = t.dec_td2[state[td2i[c]]]
+            temp2[c * 4] = (v >> 24) & 0xFF
+            temp2[c * 4 + 1] = (v >> 16) & 0xFF
+            temp2[c * 4 + 2] = (v >> 8) & 0xFF
+            temp2[c * 4 + 3] = v & 0xFF
+        for i in range(16):
+            temp1[i] = prot_xor(t.dec_round_xor, temp1[i], temp2[i])
+        for c in range(4):
+            v = t.dec_td3[state[td3i[c]]]
+            temp2[c * 4] = (v >> 24) & 0xFF
+            temp2[c * 4 + 1] = (v >> 16) & 0xFF
+            temp2[c * 4 + 2] = (v >> 8) & 0xFF
+            temp2[c * 4 + 3] = v & 0xFF
+        for i in range(16):
+            temp1[i] = prot_xor(t.dec_round_xor, temp1[i], temp2[i])
+        rk_off = r * 16
+        for i in range(16):
+            state[i] = prot_xor(t.dec_round_xor, temp1[i], key_data[rk_off + i])
+
+    inv_sr = [0, 13, 10, 7, 4, 1, 14, 11, 8, 5, 2, 15, 12, 9, 6, 3]
+    for i in range(16):
+        temp1[i] = t.dec_inv_sbox[state[inv_sr[i]]]
+    output = bytearray(16)
+    frk_off = num_rounds * 16
+    for i in range(16):
+        output[i] = prot_xor(t.dec_final_xor, temp1[i], key_data[frk_off + i])
+    return bytes(output)
+
+
+def wbc_encrypt_cbc(
+    t: WbskTables, plaintext: bytes, key_data: bytes, num_rounds: int, iv: bytes
+) -> bytes:
+    block_count = len(plaintext) // 16
+    output = bytearray(len(plaintext))
+    prev = iv
+    for b in range(block_count):
+        block = bytearray(16)
+        for i in range(16):
+            block[i] = plaintext[b * 16 + i] ^ prev[i]
+        enc = wbc_encrypt_block(t, bytes(block), key_data, num_rounds)
+        output[b * 16 : b * 16 + 16] = enc
+        prev = enc
+    return bytes(output)
+
+
+def wbc_decrypt_cbc(
+    t: WbskTables, ciphertext: bytes, key_data: bytes, num_rounds: int, iv: bytes
+) -> bytes:
+    block_count = len(ciphertext) // 16
+    output = bytearray(len(ciphertext))
+    prev = iv
+    for b in range(block_count):
+        block = ciphertext[b * 16 : b * 16 + 16]
+        dec = wbc_decrypt_block(t, block, key_data, num_rounds)
+        for i in range(16):
+            output[b * 16 + i] = dec[i] ^ prev[i]
+        prev = block
+    return bytes(output)
+
+
+def nibble_encode(buf: bytes) -> bytes:
+    out = bytearray(len(buf))
+    for i, byte in enumerate(buf):
+        out[i] = (NIBBLE_ENCODE[byte >> 4] << 4) | NIBBLE_ENCODE[byte & 0xF]
+    return bytes(out)
+
+
+def nibble_decode(buf: bytes) -> bytes:
+    out = bytearray(len(buf))
+    for i, byte in enumerate(buf):
+        out[i] = (NIBBLE_DECODE[byte >> 4] << 4) | NIBBLE_DECODE[byte & 0xF]
+    return bytes(out)
+
+
+def strip_pkcs7(buf: bytes) -> bytes:
+    if not buf:
+        return buf
+    pad_val = buf[-1]
+    if pad_val < 1 or pad_val > 16:
+        return buf
+    for i in range(len(buf) - pad_val, len(buf)):
+        if buf[i] != pad_val:
+            return buf
+    return buf[: len(buf) - pad_val]
+
+
+def add_pkcs7(buf: bytes, block_size: int = 16) -> bytes:
+    remainder = len(buf) % block_size
+    pad = block_size if remainder == 0 else block_size - remainder
+    return buf + bytes([pad]) * pad
+
+
+def wbc_input_encode(buf: bytes) -> bytes:
+    out = bytearray(len(buf))
+    for i, byte in enumerate(buf):
+        out[i] = (MYSTERY_ENCODE[byte >> 4] << 4) | MYSTERY_ENCODE[byte & 0xF]
+    return bytes(out)
+
+
+def wbc_output_decode(buf: bytes) -> bytes:
+    out = bytearray(len(buf))
+    for i, byte in enumerate(buf):
+        out[i] = (
+            (NIBBLE_ENCODE[NIBBLE_ENCODE[byte >> 4]] << 4)
+            | NIBBLE_ENCODE[NIBBLE_ENCODE[byte & 0xF]]
+        )
+    return bytes(out)
+
+
+def add_wbc_pkcs7(buf: bytes, block_size: int = 16) -> bytes:
+    remainder = len(buf) % block_size
+    pad_n = block_size if remainder == 0 else block_size - remainder
+    pad_byte = (MYSTERY_ENCODE[pad_n >> 4] << 4) | MYSTERY_ENCODE[pad_n & 0xF]
+    return buf + bytes([pad_byte]) * pad_n
+
+
+def decrypt_wbsk_envelope(
+    t: WbskTables, base64_str: str, outer_key_hex: str, inner_key_hex: str, outer_session_iv_hex: str
+) -> str:
+    raw = base64.b64decode(base64_str.strip())
+    outer_encoded = nibble_encode(raw) + bytes(256)
+    outer_key = parse_wbc_key(outer_key_hex)
+    outer_iv = bytes.fromhex(outer_session_iv_hex)
+    outer_decrypted = wbc_decrypt_cbc(t, outer_encoded, outer_key.key_data, outer_key.num_rounds, outer_iv)
+    outer_content = strip_pkcs7(nibble_decode(outer_decrypted[: len(raw)]))
+    content_len = len(outer_content)
+    inner_b64 = outer_content[: content_len - 16].decode("latin-1")
+    inner_iv = outer_decrypted[content_len - 16 : content_len]
+    inner_raw = base64.b64decode(inner_b64)
+    inner_encoded = nibble_encode(inner_raw) + bytes(256)
+    inner_key = parse_wbc_key(inner_key_hex)
+    inner_decrypted = wbc_decrypt_cbc(t, inner_encoded, inner_key.key_data, inner_key.num_rounds, inner_iv)
+    inner_content = strip_pkcs7(nibble_decode(inner_decrypted[: len(inner_raw)]))
+    return inner_content.decode("utf-8")
+
+
+def encrypt_wbsk_envelope(
+    t: WbskTables,
+    plaintext: str,
+    inner_enc_key_hex: str,
+    inner_enc_iv_hex: str,
+    outer_enc_key_hex: str,
+    outer_enc_iv_hex: str,
+) -> str:
+    plain_buf = plaintext.encode("utf-8")
+    inner_padded = add_wbc_pkcs7(wbc_input_encode(plain_buf))
+    inner_key = parse_wbc_key(inner_enc_key_hex)
+    inner_iv = bytes.fromhex(inner_enc_iv_hex)
+    inner_encrypted = wbc_encrypt_cbc(t, inner_padded, inner_key.key_data, inner_key.num_rounds, inner_iv)
+    inner_raw = wbc_output_decode(inner_encrypted)
+    inner_b64 = base64.b64encode(inner_raw).decode("ascii")
+    outer_content_plain = inner_b64.encode("latin-1") + wbc_output_decode(inner_iv)
+    outer_mystery = add_wbc_pkcs7(wbc_input_encode(outer_content_plain))
+    outer_key = parse_wbc_key(outer_enc_key_hex)
+    outer_iv = bytes.fromhex(outer_enc_iv_hex)
+    outer_encrypted = wbc_encrypt_cbc(t, outer_mystery, outer_key.key_data, outer_key.num_rounds, outer_iv)
+    return base64.b64encode(wbc_output_decode(outer_encrypted)).decode("ascii")
+
+
+def encrypt_envelope(plaintext: str) -> str:
+    t = WbskTables.get()
+    return encrypt_wbsk_envelope(
+        t,
+        plaintext,
+        WBSK_KEYS["innerEncryptKey"],
+        WBSK_KEYS["innerEncryptIv"],
+        WBSK_KEYS["outerEncryptKey"],
+        WBSK_KEYS["outerEncryptIv"],
+    )
+
+
+def decrypt_envelope(base64_str: str) -> str:
+    t = WbskTables.get()
+    return decrypt_wbsk_envelope(
+        t,
+        base64_str,
+        WBSK_KEYS["outerDecryptKey"],
+        WBSK_KEYS["innerDecryptKey"],
+        WBSK_KEYS["outerDecryptIv"],
+    )
+
+
+class WbskCodec:
+    """Stateless codec matching BangcleCodec's str-in/str-out envelope contract."""
+
+    async def async_load_tables(self) -> None:
+        """Pre-load JSON tables off the event loop (parity with ``BangcleCodec``)."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, WbskTables.get)
+
+    def encode_envelope(self, plaintext: str | bytes) -> str:
+        text = plaintext.decode("utf-8") if isinstance(plaintext, bytes) else plaintext
+        return encrypt_envelope(text)
+
+    def decode_envelope(self, envelope: str) -> bytes:
+        return decrypt_envelope(envelope).encode("utf-8")

--- a/src/pybyd/_mqtt.py
+++ b/src/pybyd/_mqtt.py
@@ -63,16 +63,27 @@ def _parse_broker(raw_broker: str) -> tuple[str, int]:
     return value, 8883
 
 
+_CN_BROKER_FIELDS: dict[str, str] = {
+    "1": "dynastyEmqBroker",
+    "2": "oceanEmqBroker",
+    "3": "denzaEmqBroker",
+    "4": "yangwangEmqBroker",
+    "5": "fangchengbaoEmqBroker",
+}
+
+
 def _build_client_id(config: BydConfig) -> str:
+    prefix = "dynasty" if config.is_china_region else "oversea"
     imei_md5 = (config.device.imei_md5 or "").strip().upper()
     if imei_md5 and set(imei_md5) != {"0"}:
-        return f"oversea_{imei_md5}"
-    return f"oversea_{md5_hex(config.device.imei)}"
+        return f"{prefix}_{imei_md5}"
+    return f"{prefix}_{md5_hex(config.device.imei)}"
 
 
 def _build_mqtt_password(session: Session, client_id: str, ts_seconds: int) -> str:
     ts_text = str(ts_seconds)
-    base = f"{session.sign_token}{client_id}{session.user_id}{ts_text}"
+    uid = session.effective_api_identifier
+    base = f"{session.sign_token}{client_id}{uid}{ts_text}"
     return f"{ts_text}{md5_hex(base)}"
 
 
@@ -93,9 +104,16 @@ async def _fetch_emq_broker(
     if not isinstance(decoded, dict):
         raise BydError("Broker lookup response inner payload is not an object")
 
-    broker = decoded.get("emqBorker") or decoded.get("emqBroker")
-    if not isinstance(broker, str) or not broker.strip():
-        raise BydError("Broker lookup response missing emqBorker/emqBroker")
+    if config.is_china_region:
+        field = _CN_BROKER_FIELDS.get(config.target_brand.strip(), "dynastyEmqBroker")
+        broker_raw = decoded.get(field)
+        broker = broker_raw if isinstance(broker_raw, str) else ""
+    else:
+        broker = decoded.get("emqBorker") or decoded.get("emqBroker")
+        if not isinstance(broker, str):
+            broker = ""
+    if not broker.strip():
+        raise BydError("Broker lookup response missing broker host")
     return broker.strip()
 
 
@@ -109,13 +127,15 @@ async def fetch_mqtt_bootstrap(
     broker_host, broker_port = _parse_broker(broker)
     client_id = _build_client_id(config)
     now_seconds = int(time.time())
+    uid = session.effective_api_identifier
+    prefix = "dynasty" if config.is_china_region else "oversea"
     return MqttBootstrap(
-        user_id=session.user_id,
+        user_id=uid,
         broker_host=broker_host,
         broker_port=broker_port,
-        topic=f"oversea/res/{session.user_id}",
+        topic=f"{prefix}/res/{uid}",
         client_id=client_id,
-        username=session.user_id,
+        username=uid,
         password=_build_mqtt_password(session, client_id, now_seconds),
     )
 

--- a/src/pybyd/_transport.py
+++ b/src/pybyd/_transport.py
@@ -1,4 +1,4 @@
-"""HTTP transport with Bangcle envelope wrapping."""
+"""HTTP transport with Bangcle or WBSK envelope wrapping."""
 
 from __future__ import annotations
 
@@ -10,11 +10,20 @@ from typing import Any, Protocol
 import aiohttp
 
 from pybyd._constants import USER_AGENT
-from pybyd._crypto.bangcle import BangcleCodec
 from pybyd.config import BydConfig
 from pybyd.exceptions import BydTransportError
 
 _logger = logging.getLogger(__name__)
+
+
+class EnvelopeCodec(Protocol):
+    """Encode/decode outer JSON string for the wire format (Bangcle or WBSK)."""
+
+    async def async_load_tables(self) -> None: ...
+
+    def encode_envelope(self, plaintext: str | bytes) -> str: ...
+
+    def decode_envelope(self, envelope: str) -> bytes: ...
 
 
 class Transport(Protocol):
@@ -28,7 +37,7 @@ class Transport(Protocol):
 
 
 class SecureTransport:
-    """HTTP transport that handles Bangcle envelope encoding.
+    """HTTP transport that handles Bangcle or WBSK envelope encoding.
 
     Cookie persistence is delegated to the ``aiohttp.ClientSession``'s
     built-in ``CookieJar`` — callers should create the session with
@@ -38,7 +47,7 @@ class SecureTransport:
     def __init__(
         self,
         config: BydConfig,
-        codec: BangcleCodec,
+        codec: EnvelopeCodec,
         http_session: aiohttp.ClientSession,
         *,
         logger: logging.Logger | None = None,
@@ -49,21 +58,25 @@ class SecureTransport:
         self._logger = logger or _logger
 
     async def post_secure(self, endpoint: str, outer_payload: Mapping[str, Any]) -> dict[str, Any]:
-        """Send a signed request through the Bangcle envelope layer.
+        """Send a signed request through the envelope layer.
 
         1. JSON-encode the outer payload
-        2. Bangcle-encode it
+        2. Codec-encode it (Bangcle ``F``+base64 or WBSK base64)
         3. POST as ``{"request": "<encoded>"}``
-        4. Bangcle-decode the ``{"response": "<encoded>"}`` reply
+        4. Decode the ``{"response": "<encoded>"}`` reply
         5. Return the decoded JSON dict
         """
-        encoded = self._codec.encode_envelope(json.dumps(outer_payload, separators=(",", ":")))
+        encoded = self._codec.encode_envelope(json.dumps(outer_payload, separators=(",", ":"), ensure_ascii=False))
 
         headers: dict[str, str] = {
             "accept-encoding": "identity",
             "content-type": "application/json; charset=UTF-8",
             "user-agent": USER_AGENT,
         }
+        if self._config.is_china_region:
+            headers["version"] = self._config.cn_app_inner_version
+            headers["platform"] = "ANDROID"
+            headers["BrandFlag"] = self._config.brand_flag
 
         url = f"{self._config.base_url}{endpoint}"
         body = json.dumps({"request": encoded})
@@ -110,7 +123,7 @@ class SecureTransport:
 
         decoded_text = self._codec.decode_envelope(response_str).decode("utf-8").strip()
 
-        # Handle stray F prefix on decoded JSON (observed in some responses)
+        # Handle stray F prefix on decoded JSON (observed in some Bangcle responses)
         if decoded_text.startswith("F{") or decoded_text.startswith("F["):
             decoded_text = decoded_text[1:]
 
@@ -118,7 +131,7 @@ class SecureTransport:
             result: dict[str, Any] = json.loads(decoded_text)
         except json.JSONDecodeError as exc:
             raise BydTransportError(
-                f"Bangcle response from {endpoint} is not JSON: {decoded_text[:64]}",
+                f"Envelope response from {endpoint} is not JSON: {decoded_text[:64]}",
                 endpoint=endpoint,
             ) from exc
 

--- a/src/pybyd/_validators.py
+++ b/src/pybyd/_validators.py
@@ -47,7 +47,7 @@ from collections.abc import Callable
 from typing import Any
 
 from pybyd.models.gps import GpsInfo
-from pybyd.models.realtime import VehicleRealtimeData
+from pybyd.models.realtime import DoorOpenState, VehicleRealtimeData
 
 _GPS_NULL_ISLAND_THRESHOLD: float = 0.1
 _MISSING: object = object()
@@ -80,6 +80,19 @@ _PRESERVE_WHEN_NONE_FIELD_NAMES: tuple[str, ...] = (
     "total_energy",
     "total_consumption",
     "total_consumption_en",
+)
+
+# Door/trunk open sensors: API often reports CLOSED (0) as a non-authoritative
+# default; treat like numeric zero-drop (preserve previous OPEN, drop CLOSED
+# when there is no prior value).
+_DOOR_CLOSED_NOISE_FIELD_NAMES: tuple[str, ...] = (
+    "left_front_door",
+    "right_front_door",
+    "left_rear_door",
+    "right_rear_door",
+    "trunk_lid",
+    "sliding_door",
+    "forehold",
 )
 
 RealtimeFieldFilter = Callable[[str, Any, Any, bool], Any | object]
@@ -158,9 +171,27 @@ def _preserve_when_none_filter(
     return _MISSING
 
 
+def _door_closed_noise_filter(
+    _: str,
+    previous_value: Any,
+    incoming_value: Any,
+    incoming_present: bool,
+) -> Any | object:
+    """Drop ambiguous CLOSED readings unless we already have a stronger signal."""
+    if not incoming_present:
+        return _MISSING
+    is_closed = incoming_value == DoorOpenState.CLOSED or incoming_value == 0
+    if not is_closed:
+        return _MISSING
+    if previous_value is None:
+        return None
+    return previous_value
+
+
 _REALTIME_FIELD_FILTERS: dict[str, tuple[RealtimeFieldFilter, ...]] = {
     **{field_name: (_drop_zero_value_filter,) for field_name in _ZERO_DROP_FIELD_NAMES},
     **{field_name: (_preserve_when_none_filter,) for field_name in _PRESERVE_WHEN_NONE_FIELD_NAMES},
+    **{field_name: (_door_closed_noise_filter,) for field_name in _DOOR_CLOSED_NOISE_FIELD_NAMES},
 }
 
 
@@ -207,7 +238,7 @@ def apply_realtime_filters(
     """Apply all realtime filtering rules in one place.
 
     Rules currently include:
-    - selected realtime zero-drop gating (doors/locks, SOC/range/tire pressure/odometer).
+    - selected realtime zero-drop gating (door open sensors, locks, SOC/range/tire pressure/odometer).
 
     The returned model is either:
     - the original incoming payload when no override is needed, or

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -24,7 +24,10 @@ from pybyd._api import smart_charging as _smart_api
 from pybyd._api import vehicle as _vehicle_api
 from pybyd._api import vehicle_settings as _settings_api
 from pybyd._api.login import build_login_request, parse_login_response
+from pybyd._api.login_cn import build_cn_login_request, parse_cn_login_response
 from pybyd._crypto.bangcle import BangcleCodec
+from pybyd._crypto.wbsk import WbskCodec
+from pybyd._transport import EnvelopeCodec
 from pybyd._crypto.hashing import md5_hex
 from pybyd._mqtt import BydMqttRuntime, MqttEvent, fetch_mqtt_bootstrap
 from pybyd._transport import SecureTransport
@@ -130,7 +133,7 @@ class BydClient:
         self._config = config
         self._external_session = session is not None
         self._http_session = session
-        self._codec = BangcleCodec()
+        self._codec: EnvelopeCodec = WbskCodec() if config.is_china_region else BangcleCodec()
         self._transport: SecureTransport | None = None
         self._session: Session | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -184,7 +187,7 @@ class BydClient:
             self._http_session,
             logger=_logger,
         )
-        await self._codec.async_load_tables()
+        await self._codec.async_load_tables()  # Bangcle loads .bin; WBSK loads JSON tables
 
     async def async_close(self) -> None:
         """Tear down the client transport and MQTT connection.
@@ -211,15 +214,25 @@ class BydClient:
     async def login(self) -> None:
         """Authenticate against the BYD API and obtain session tokens."""
         transport = self._require_transport()
-        outer = build_login_request(self._config, _now_ms())
-        response = await transport.post_secure("/app/account/login", outer)
-        token = parse_login_response(response, self._config.password)
+        if self._config.is_china_region:
+            outer = build_cn_login_request(self._config, _now_ms())
+            response = await transport.post_secure("/app/auth/login", outer)
+            token = parse_cn_login_response(
+                response,
+                self._config.password,
+                target_brand=self._config.target_brand,
+            )
+        else:
+            outer = build_login_request(self._config, _now_ms())
+            response = await transport.post_secure("/app/account/login", outer)
+            token = parse_login_response(response, self._config.password)
 
         ttl = self._config.session_ttl if self._config.session_ttl > 0 else float("inf")
         self._session = Session(
             user_id=token.user_id,
             sign_token=token.sign_token,
             encry_token=token.encry_token,
+            super_id=token.super_id,
             ttl=ttl,
         )
         # Update the running MQTT runtime's key immediately so any
@@ -1019,6 +1032,19 @@ class BydClient:
         """
 
         async def _call() -> GpsInfo:
+            if self._config.is_china_region:
+                session = await self.ensure_session()
+                transport = self._require_transport()
+                decoded, _serial = await _gps_api.fetch_gps_endpoint(
+                    "/vehicleInfo/gps/locationRequestService",
+                    self._config,
+                    session,
+                    transport,
+                    vin,
+                    None,
+                )
+                return GpsInfo.model_validate(decoded)
+
             return await self._trigger_and_poll(
                 vin=vin,
                 trigger_endpoint="/control/getGpsInfo",

--- a/src/pybyd/config.py
+++ b/src/pybyd/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 
 def _env_bool(value: str | None, default: bool) -> bool:
@@ -94,6 +94,23 @@ class BydConfig(BaseModel):
         GPS, remote commands).
     device : DeviceProfile
         Device identity fields.
+    app_channel : str
+        CN app channel (default ``"99"``).
+    cn_app_version : str
+        CN app version string for login inner payload.
+    cn_app_inner_version : str
+        CN internal app version; also sent as HTTP header ``version`` in CN mode.
+    target_brand : str
+        CN brand id for signing and MQTT broker field selection (e.g. ``"1"`` dynasty).
+    vehicle_brand : str
+        CN vehicle brand id in token outer envelope.
+    network_operator : str
+        CN network operator string (default Unicode ``无``).
+    brand_flag : str
+        HTTP header ``BrandFlag`` in CN mode (reference app uses ``dynasty``).
+    region : str or None
+        Optional ``"cn"`` or ``"overseas"`` from ``BYD_REGION`` to force API region
+        instead of inferring from ``base_url``.
     """
 
     model_config = ConfigDict(
@@ -120,6 +137,30 @@ class BydConfig(BaseModel):
     mqtt_keepalive: int = 120
     mqtt_timeout: float = 10.0
     device: DeviceProfile = Field(default_factory=DeviceProfile)
+    app_channel: str = "99"
+    cn_app_version: str = "9.10.2"
+    cn_app_inner_version: str = "502"
+    target_brand: str = "1"
+    vehicle_brand: str = "1"
+    network_operator: str = "\u65e0"
+    brand_flag: str = "dynasty"
+    region: str | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_china_region(self) -> bool:
+        """True when using China API (WBSK, CN endpoints).
+
+        Uses ``BYD_REGION`` when set to ``cn`` or ``overseas``; otherwise detects
+        ``cn.byd.auto`` in ``base_url`` (same rule as BYD-re ``client.js``).
+        """
+        if self.region is not None:
+            normalized = self.region.strip().lower()
+            if normalized == "cn":
+                return True
+            if normalized in {"overseas", "eu", "intl", "global"}:
+                return False
+        return "cn.byd.auto" in self.base_url.lower()
 
     @classmethod
     def from_env(cls, **overrides: Any) -> BydConfig:
@@ -184,6 +225,14 @@ class BydConfig(BaseModel):
             "BYD_TBOX_VERSION": "tbox_version",
             "BYD_IS_AUTO": "is_auto",
             "BYD_CONTROL_PIN": "control_pin",
+            "BYD_APP_CHANNEL": "app_channel",
+            "BYD_CN_APP_VERSION": "cn_app_version",
+            "BYD_CN_APP_INNER_VERSION": "cn_app_inner_version",
+            "BYD_TARGET_BRAND": "target_brand",
+            "BYD_VEHICLE_BRAND": "vehicle_brand",
+            "BYD_NETWORK_OPERATOR": "network_operator",
+            "BYD_BRAND_FLAG": "brand_flag",
+            "BYD_REGION": "region",
         }
         config_kwargs: dict[str, Any] = {"device": device}
         for env_key, field_name in _ENV_CONFIG_MAP.items():

--- a/src/pybyd/models/_base.py
+++ b/src/pybyd/models/_base.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import enum
 import math
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Annotated, Any, ClassVar
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
@@ -54,17 +54,95 @@ COMMON_KEY_ALIASES: dict[str, str] = {
 # Threshold to distinguish seconds from milliseconds.
 _MS_THRESHOLD = 1_000_000_000_000
 
+# China (and some overseas) vehicle payloads use Java-style date strings, e.g.
+# ``Sat Nov 22 00:00:00 CST 2025`` for ``autoBoughtTime``. Parse without relying
+# on system locale for ``%b``.
+_EN_MONTH: dict[str, int] = {
+    m: i
+    for i, m in enumerate(
+        ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"),
+        start=1,
+    )
+}
+
+# Offset hours for the timezone token in those strings (CN uses CST = UTC+8).
+_JAVA_DATE_TZ_OFFSET_HOURS: dict[str, int] = {
+    "CST": 8,
+    "GMT": 0,
+    "UTC": 0,
+}
+
+
+def _parse_java_style_date_string(s: str) -> datetime | None:
+    """Parse ``Wed Nov 22 00:00:00 CST 2025`` into UTC (fixed-offset TZ only)."""
+    parts = s.split()
+    if len(parts) != 6:
+        return None
+    _wk, mon, day_s, hms, tz_token, year_s = parts
+    mon_num = _EN_MONTH.get(mon)
+    if mon_num is None:
+        return None
+    offset_h = _JAVA_DATE_TZ_OFFSET_HOURS.get(tz_token)
+    if offset_h is None:
+        return None
+    try:
+        day = int(day_s)
+        year = int(year_s)
+        h, m, sec = (int(x) for x in hms.split(":"))
+    except ValueError:
+        return None
+
+    naive = datetime(year, mon_num, day, h, m, sec)
+    src_tz = timezone(timedelta(hours=offset_h))
+    return naive.replace(tzinfo=src_tz).astimezone(UTC)
+
 
 def parse_byd_timestamp(value: Any) -> datetime | None:
-    """Convert a BYD epoch timestamp (seconds **or** milliseconds) to a UTC datetime.
+    """Convert a BYD time value to a UTC datetime.
 
-    Returns ``None`` when the value is ``None`` or not numeric.
+    Accepts:
+
+    * epoch seconds or milliseconds (int/float or numeric string),
+    * ISO-8601 strings (with optional ``Z``),
+    * Java-style locale strings with English month abbreviations and a known
+      ``CST``/``GMT``/``UTC`` token (common on CN vehicle list payloads).
+
+    Returns ``None`` when the value is ``None``, empty, or not recognised.
     """
     if value is None:
-        return value
+        return None
     if isinstance(value, datetime):
-        return value
-    ts = int(value)
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped or stripped in _SENTINELS:
+            return None
+        parsed_java = _parse_java_style_date_string(stripped)
+        if parsed_java is not None:
+            return parsed_java
+        iso = stripped.replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(iso)
+        except ValueError:
+            pass
+        else:
+            if dt.tzinfo is None:
+                return dt.replace(tzinfo=UTC)
+            return dt.astimezone(UTC)
+        try:
+            ts = int(stripped)
+        except ValueError:
+            return None
+    else:
+        try:
+            ts = int(value)
+        except (TypeError, ValueError):
+            try:
+                ts = int(float(value))
+            except (TypeError, ValueError):
+                return None
     if ts >= _MS_THRESHOLD:
         ts = ts // 1000
     return datetime.fromtimestamp(ts, tz=UTC)

--- a/src/pybyd/models/token.py
+++ b/src/pybyd/models/token.py
@@ -18,6 +18,8 @@ class AuthToken(BaseModel):
         Token for signature key derivation.
     encry_token : str
         Token for encryption key derivation.
+    super_id : str or None
+        CN ``superId`` when present; used for MQTT and outer ``identifier``.
     raw : dict
         Full decoded token dict for access to additional fields.
     """
@@ -27,4 +29,5 @@ class AuthToken(BaseModel):
     user_id: str
     sign_token: str
     encry_token: str
+    super_id: str | None = None
     raw: dict[str, Any]

--- a/src/pybyd/session.py
+++ b/src/pybyd/session.py
@@ -15,7 +15,9 @@ class Session(BaseModel):
     Parameters
     ----------
     user_id : str
-        The authenticated user's ID.
+        The authenticated user's ID (brand-specific on CN when available).
+    super_id : str or None
+        CN super account id for MQTT username / outer identifier.
     sign_token : str
         Token used for request signature derivation.
     encry_token : str
@@ -38,8 +40,16 @@ class Session(BaseModel):
     user_id: str
     sign_token: str
     encry_token: str
+    super_id: str | None = None
     created_at: float = Field(default_factory=time.monotonic)
     ttl: float = 12 * 3600
+
+    @property
+    def effective_api_identifier(self) -> str:
+        """Identifier for CN outer payloads and MQTT (``superId`` preferred)."""
+        if self.super_id:
+            return self.super_id
+        return self.user_id
 
     def content_key(self) -> str:
         """AES key for encrypting/decrypting inner payload data.

--- a/tests/test_byd_timestamp.py
+++ b/tests/test_byd_timestamp.py
@@ -1,0 +1,36 @@
+"""Tests for parse_byd_timestamp / CN date strings on Vehicle."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pybyd.models._base import parse_byd_timestamp
+from pybyd.models.vehicle import Vehicle
+
+
+def test_parse_java_style_cst() -> None:
+    dt = parse_byd_timestamp("Sat Nov 22 00:00:00 CST 2025")
+    assert dt is not None
+    assert dt.tzinfo == UTC
+    # 2025-11-22 00:00 CST = 2025-11-21 16:00 UTC
+    assert dt.year == 2025
+    assert dt.month == 11
+    assert dt.day == 21
+    assert dt.hour == 16
+
+
+def test_vehicle_auto_bought_time_cn_string() -> None:
+    v = Vehicle.model_validate(
+        {
+            "vin": "LGXCF6CD0R0123456",
+            "autoBoughtTime": "Sat Nov 22 00:00:00 CST 2025",
+        }
+    )
+    assert v.auto_bought_time is not None
+    assert v.auto_bought_time.tzinfo == UTC
+
+
+def test_parse_epoch_ms_unchanged() -> None:
+    dt = parse_byd_timestamp(1_700_000_000_000)
+    assert dt is not None
+    assert dt == datetime.fromtimestamp(1_700_000_000, tz=UTC)

--- a/tests/test_wbsk.py
+++ b/tests/test_wbsk.py
@@ -1,0 +1,130 @@
+"""Golden vectors from BYD-re ``scripts/test_wbsk.js``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pybyd._crypto import wbsk
+
+
+def test_parse_wbc_key_encrypt_mode() -> None:
+    enc_key = (
+        "9fca018f72712b15e23c275ea5e06a92d8b98404cf0bf960955596ff47dd2adf8f9e0c3ca1363e8be88cb6fced211933e5c3484c20c7bc3ae1eb8541027fef4a20b2f302d93582f7f4349fef05c16d389956ae9f2a7aea278fd5232229e38caca017ffbaf5138d2cadbca917b4694fb2882a64809c095387b7353608ca3a17913e5863770465986995c684ea7db01e0c35c69fd169a8e14ec5123beb5b8dad6e1c5198f34ed1c44d5f9b15035673df5953e5e42351f58052c1483fa4cf93c646a396081355a46d5a7e0ce30d54049802829cd78c1a77c7db8f74acb244b73c5147f161ee25bd702112cec97c339a6b3314527d12"
+    )
+    parsed = wbsk.parse_wbc_key(enc_key)
+    assert parsed.mode == 0x10
+    assert parsed.num_rounds == 14
+
+
+def test_parse_wbc_key_decrypt_mode() -> None:
+    dec_key = (
+        "72ca0163b22e2973656a67ac1ae1490a61133824a0cd235bcfcd6032dba79d3ca51b1c4d1b03068566ff084645dcc9e6e8a28b39c71e72dec3fe4074109a84f5564d3f43f4854fb634bf633dabe218a5b73470dff70b07161b76c74d92bffa15bcb7fa4fc448a0fe83b62c9dd97f36d1d1d7613028041bb1dd328397bbf8c8bf6f81321f5e2d4982761a375bded52a1de198169839fabad771bc677b57f806c1ca385f43627e9a5081c43d7c9d9fa86e7e78cc0a8050a2420a76c842abbe93eb38f2487bdf93087cd24097a16539da2f86feb693432daf8f0618cbf97ffea3a762b7b91050f8634a8d3ceb25ea7d2b3264a77337"
+    )
+    parsed = wbsk.parse_wbc_key(dec_key)
+    assert parsed.mode == 0x11
+
+
+def test_wbc_encrypt_block() -> None:
+    t = wbsk.WbskTables.get()
+    enc_key = wbsk.parse_wbc_key(
+        "9fca018f72712b15e23c275ea5e06a92d8b98404cf0bf960955596ff47dd2adf8f9e0c3ca1363e8be88cb6fced211933e5c3484c20c7bc3ae1eb8541027fef4a20b2f302d93582f7f4349fef05c16d389956ae9f2a7aea278fd5232229e38caca017ffbaf5138d2cadbca917b4694fb2882a64809c095387b7353608ca3a17913e5863770465986995c684ea7db01e0c35c69fd169a8e14ec5123beb5b8dad6e1c5198f34ed1c44d5f9b15035673df5953e5e42351f58052c1483fa4cf93c646a396081355a46d5a7e0ce30d54049802829cd78c1a77c7db8f74acb244b73c5147f161ee25bd702112cec97c339a6b3314527d12"
+    )
+    enc_input = bytes.fromhex("f355d6f4f4c7d0d6d9d9ded855715572")
+    enc_iv = bytes.fromhex("98893a8b94a08d89999b8f3684ab9589")
+    xored = bytes(enc_input[i] ^ enc_iv[i] for i in range(16))
+    enc_result = wbsk.wbc_encrypt_block(t, xored, enc_key.key_data, enc_key.num_rounds)
+    assert enc_result.hex() == "a368c168ee2db39b7a555738e498f084"
+
+
+def test_wbc_decrypt_block_cbc1() -> None:
+    t = wbsk.WbskTables.get()
+    dec_key = wbsk.parse_wbc_key(
+        "72ca0163b22e2973656a67ac1ae1490a61133824a0cd235bcfcd6032dba79d3ca51b1c4d1b03068566ff084645dcc9e6e8a28b39c71e72dec3fe4074109a84f5564d3f43f4854fb634bf633dabe218a5b73470dff70b07161b76c74d92bffa15bcb7fa4fc448a0fe83b62c9dd97f36d1d1d7613028041bb1dd328397bbf8c8bf6f81321f5e2d4982761a375bded52a1de198169839fabad771bc677b57f806c1ca385f43627e9a5081c43d7c9d9fa86e7e78cc0a8050a2420a76c842abbe93eb38f2487bdf93087cd24097a16539da2f86feb693432daf8f0618cbf97ffea3a762b7b91050f8634a8d3ceb25ea7d2b3264a77337"
+    )
+    dec_input = bytes.fromhex("ac167b36509cd8b448bc5b6544ad0a80")
+    dec_iv = bytes.fromhex("54cc5558c551c155c4c05cc4c158ca58")
+    dec_block = wbsk.wbc_decrypt_block(t, dec_input, dec_key.key_data, dec_key.num_rounds)
+    dec_result = bytes(dec_block[i] ^ dec_iv[i] for i in range(16))
+    assert dec_result.hex() == "99c9911c5317c0595cc459c8d8d8dcc0"
+
+
+def test_wbc_decrypt_block_cbc2() -> None:
+    t = wbsk.WbskTables.get()
+    dec2_key = wbsk.parse_wbc_key(
+        "71ca0160b689febe1c11e07bc8f8cec81decf71b6c3e0be299a35211888c2fb177958e57a6e971d0a874ecb50991786faf3a34b178f13a668bd14b81a82d3f799f6f0c8bd002406c8b6fdd54b3bb30c0c7d27c906dba87decde28717a0874abacf41755646b4a2c06854615ab00ae53136cbea3302b047659e7a42f792a7369fc130d8ffdc114a7a2cf2fa669b9b337905ff58fe3cc40b9b1edf37ebe50d36b3416abbd32837895b8ea1f22b9eab35efd791d9153208630297b8b953a9ca33265854c33959979b9eb1d049326986851170f4b51d151f43a30c6298a8c03503477336b2000c49746181ca30eabded6d3088b7f615"
+    )
+    dec2_input = bytes.fromhex("9ca134a1bb87dc5de9666ec1b251f012")
+    dec2_iv = bytes.fromhex("5115c91d52901715555d1fca129d5615")
+    dec2_block = wbsk.wbc_decrypt_block(t, dec2_input, dec2_key.key_data, dec2_key.num_rounds)
+    dec2_result = bytes(dec2_block[i] ^ dec2_iv[i] for i in range(16))
+    assert dec2_result.hex() == "de4458d0d01c52585757595344c644ca"
+
+
+def test_nibble_encode_decode() -> None:
+    nib_test = bytes([0x93])
+    enc = wbsk.nibble_encode(nib_test)
+    assert enc[0].to_bytes(1, "big").hex() == "ac"
+    assert wbsk.nibble_decode(enc) == nib_test
+
+
+@pytest.fixture
+def test_envelope() -> str:
+    return (
+        "k0rtymBTcdIh022mIpcJEMGrPoHX2Qz2jwcluQ300c0X2oQVmVi92chOWl6iWgTiy6cteRnVFgm8SWVamBCTRTJNJ46s79Yrj3PqTACkyi178Q1iWq3onlsyenp8Rc9XEw+mqFmA9H8ls8pABVpW+tLfGipTZycvbkp9SS6wTmdmHd4+POky6LV4r3XeQ+qchV6Ldkkvd6CwHL4U5VvPiFSP26G9YoZCS5ddr8sbPnGW3cOKwMh2x2e6lZMNtTbE5dQd2sct9pm7/pKhs72EeOV36g+Y+iZvEIOVixAVNf+ipnRN/TiNA6sG36b/9vF5SBz7kCs2fmTCNf9eU4qka4t/MBPGFXV8ybNNQtfF6FZub0NrhkiPT1QDXfr2mfoe8/29Wf/kISW4E3aRKXmWW4fLuzUpdhYirjzie6ROwkoEGM9UVQVV5h3Ff4m5lcEIQQmXgoX98qyHKBpWDdq7bsTkpFY1MgzNEkH88aO6mLkv9AF9Xlm+Q9ehtVA0eYfaE0+Tf5boUD/vSTlPljxmLwTq2VfXjYIioxpMr1HGx6LRUDFzNUjL9hsM/Fi2hXRsTl194nnrrvqw1tfKim7m5k4KXMRnvcoHEiAZCaxSxZVUhyVcnPvHbmsp9/0LZPLKOrromENif2lJ4a1L7cTsmnt+OaoffcIOCouh2JY5+CgoMYwg+3wg4YUdDhogOxqJweQnlB7xFNnjCzhk0p7BuQpMq4tIa6LG3ddfL+Zug1Q4SYHWxMU5SEAdOujT4pwCuzDAxOt0cVISiDbPh7YGy5uesILUA1/JSj/IrQZg5BzzWChKPU18eoyTdSj631sJLKVolOH4UjXU0riZDuxtFtXkn9xjNKoUjX/Km0bFZT2ivHCA29kqME8vEWybrXt8Rt9+ksV52ymzLnHiU61TlYWtYU6rmTfo5pGjWRELaxhJbZBjK7Y9B87Wn2rJey/b+HO+y4WqL0IUs4mspS/ocP4UExRGQLvN+jWN2DrmMz7fi0VXYXCrnJ1Q1aCbhLvrtySBH7qOhsEBMmOqHA7n0P4be4jOyo/0WxVs0AwlQhgjPNstQErRp7A/dkY/p+uYr8OT5GsCQ+f4fsZeQ3+DIsv3sWXbn7OMIxmFaJZ5pMkCl2SbPiehUWdIL3vrcRtVR8CT3JSaI9BpOo9CRvkhZvjBYhaMwEJPljXepPxwFiiZJRzytzZAJq0HPuVamP1tE7T4tWDXgHTgycQeMHE6E+HeKrOFaCDIr09vpIhfHohvkUs0bEyiSzejmqJHyV7MW1vJ5v2V9l5SoQYMhvKuwL/MujQlsQEqi97+U25+w5Y="
+    )
+
+
+def test_decrypt_wbsk_envelope_golden(test_envelope: str) -> None:
+    t = wbsk.WbskTables.get()
+    outer_key = "72ca0163b22e2973656a67ac1ae1490a61133824a0cd235bcfcd6032dba79d3ca51b1c4d1b03068566ff084645dcc9e6e8a28b39c71e72dec3fe4074109a84f5564d3f43f4854fb634bf633dabe218a5b73470dff70b07161b76c74d92bffa15bcb7fa4fc448a0fe83b62c9dd97f36d1d1d7613028041bb1dd328397bbf8c8bf6f81321f5e2d4982761a375bded52a1de198169839fabad771bc677b57f806c1ca385f43627e9a5081c43d7c9d9fa86e7e78cc0a8050a2420a76c842abbe93eb38f2487bdf93087cd24097a16539da2f86feb693432daf8f0618cbf97ffea3a762b7b91050f8634a8d3ceb25ea7d2b3264a77337"
+    inner_key = "71ca0160b689febe1c11e07bc8f8cec81decf71b6c3e0be299a35211888c2fb177958e57a6e971d0a874ecb50991786faf3a34b178f13a668bd14b81a82d3f799f6f0c8bd002406c8b6fdd54b3bb30c0c7d27c906dba87decde28717a0874abacf41755646b4a2c06854615ab00ae53136cbea3302b047659e7a42f792a7369fc130d8ffdc114a7a2cf2fa669b9b337905ff58fe3cc40b9b1edf37ebe50d36b3416abbd32837895b8ea1f22b9eab35efd791d9153208630297b8b953a9ca33265854c33959979b9eb1d049326986851170f4b51d151f43a30c6298a8c03503477336b2000c49746181ca30eabded6d3088b7f615"
+    outer_iv = "54cc5558c551c155c4c05cc4c158ca58"
+    result = wbsk.decrypt_wbsk_envelope(t, test_envelope, outer_key, inner_key, outer_iv)
+    expected = '{"appChannel":"99","deviceName":"XIAOMIPOCO F1","deviceType":"0","devicename":"XIAOMIPOCO F1","functionType":"0","identifier":"","identifierType":2,"imeiMD5":"B3F1683F5F6D4AFA68D5E6C8403EB762","mobileBrand":"XIAOMI","mobileModel":"POCO F1","networkOperator":"\u65e0","networkType":"WiFi","osType":"Android","osVersion":"15","random":"4147E42713B5443D92C4FD83A4A36DF4","reqTimestamp":"1772115257753","sign":"","softType":"0","targetBrand":"1","timeStamp":"1772115257","vehicleBrand":"1","version":"502","ostype":"and","imei":"unknown","mac":"unknown","model":"unknown","sdk":"unknown","serviceTime":"1772115257808","mod":"unknown","checkcode":"2eb5bb65dc1c49496824ba0462f62b2aa99ffcbbe62680028a41a197a6045718"}'
+    assert json.loads(result) == json.loads(expected)
+
+
+def test_encrypt_decrypt_roundtrip() -> None:
+    payload = '{"hello":"world","num":42}'
+    enc = wbsk.encrypt_envelope(payload)
+    dec = wbsk.decrypt_envelope(enc)
+    assert json.loads(dec) == json.loads(payload)
+
+
+def test_cn_payload_roundtrip() -> None:
+    cn_payload = json.dumps(
+        {
+            "appChannel": "99",
+            "deviceName": "XIAOMIPOCO F1",
+            "deviceType": "0",
+            "functionType": "0",
+            "identifier": "13145797664",
+            "identifierType": "0",
+            "imeiMD5": "B3F1683F5F6D4AFA68D5E6C8403EB762",
+            "mobileBrand": "XIAOMI",
+            "mobileModel": "POCO F1",
+            "networkType": "WiFi",
+            "osType": "Android",
+            "osVersion": "15",
+            "random": "4147E42713B5443D92C4FD83A4A36DF4",
+            "reqTimestamp": "1772115257753",
+            "sign": "",
+            "softType": "0",
+            "targetBrand": "1",
+            "timeStamp": "1772115257",
+            "vehicleBrand": "1",
+            "version": "502",
+        },
+        separators=(",", ":"),
+    )
+    enc = wbsk.encrypt_envelope(cn_payload)
+    dec = wbsk.decrypt_envelope(enc)
+    assert json.loads(dec) == json.loads(cn_payload)
+
+
+def test_wbsk_codec_interface() -> None:
+    codec = wbsk.WbskCodec()
+    enc = codec.encode_envelope('{"a":1}')
+    assert codec.decode_envelope(enc).decode("utf-8") == '{"a":1}'


### PR DESCRIPTION
# pyBYD China (CN) API support

## Gap analysis (current pyBYD vs CN)

Today pyBYD is **overseas-only**:

- HTTP transport always Bangcle-wraps bodies via [`SecureTransport`](/src/pybyd/_transport.py) + [`BangcleCodec`](/src/pybyd/_crypto/bangcle.py).
- Login is hardwired to [`/app/account/login`](/src/pybyd/_api/login.py) and [`BydClient.login`](/src/pybyd/client.py).
- Token envelopes use overseas outer shape + MD5 chunk-reordered `checkcode` in [`build_token_outer_envelope`](/src/pybyd/_api/_envelope.py) and [`compute_checkcode`](/src/pybyd/_crypto/hashing.py).
- Inner “base” fields for most calls are minimal in [`build_inner_base`](/src/pybyd/_api/_common.py) (no CN device block).
- Vehicle list uses only [`/app/account/getAllListByUserId`](/src/pybyd/_api/vehicle.py) and assumes a top-level JSON array.
- MQTT bootstrap assumes `emqBroker` / `emqBorker`, `oversea_` client id, and topic `oversea/res/...` in [`_mqtt.py`](/src/pybyd/_mqtt.py).
- GPS uses overseas trigger/poll [`/control/getGpsInfo` + `/control/getGpsInfoResult`](/src/pybyd/_api/gps.py) via [`get_gps_info`](/src/pybyd/client.py).

CN behavior is specified in [BYD-re README](D:/PROJ/PET_PROJ/BYD/BYD-re/README.md) and implemented in [BYD-re `client.js`](D:/PROJ/PET_PROJ/BYD/BYD-re/client.js) (detected by `CN_MODE = /cn\.byd\.auto/i.test(BASE_URL)`).

The CN sample in [`status.html`](D:/PROJ/PET_PROJ/BYD/BYD-re/status.html) confirms: same realtime paths (`vehicleRealTimeRequest` / `vehicleRealTimeResult`), GPS via `/vehicleInfo/gps/locationRequestService` with coordinates in the decrypted payload, token field `encryToken`, top-level `userId` matching the account id used for MQTT-style flows, and CN-rich vehicle objects (still `vin`-keyed).

```mermaid
flowchart LR
  subgraph overseas [Overseas]
    B[Bangcle envelope]
    L1["/app/account/login"]
    VL1["/app/account/getAllListByUserId"]
    G1["getGpsInfo + poll Result"]
  end
  subgraph cn [CN]
    W[WBSK envelope]
    L2["/app/auth/login"]
    VL2["/app/auth/getAllListByUserId"]
    G2["locationRequestService once"]
  end
  App[BydClient] --> overseas
  App --> cn
```

## Module layout (CN vs overseas separation)

Keep overseas code paths in existing files; add **dedicated CN modules** under `src/pybyd/_api/` so future CN-only changes stay localized.

| File | Responsibility |
|------|----------------|
| [`login.py`](/src/pybyd/_api/login.py) | Overseas only: `build_login_request`, `parse_login_response` (unchanged surface). |
| **`login_cn.py`** (new) | `build_cn_login_request`, `parse_cn_login_response` (or `parse_login_response_cn`): CN outer payload, `/app/auth/login`, `superId` / `encryptToken` handling. |
| [`_envelope.py`](/src/pybyd/_api/_envelope.py) | Overseas only: `build_token_outer_envelope` + MD5 checkcode (unchanged). |
| **`cn_envelope.py`** (new) | `build_cn_token_outer_envelope(config, session, inner, now_ms, ...)`, CN `sign_fields` / outer dict / `addCnDeviceFields` + SHA-256 checkcode ordering; **`build_cn_inner_base`** (and a small helper for vehicle list inner, e.g. `build_cn_vehicle_list_inner`, = CN inner + `appUiName: ""`). |
| [`_common.py`](/src/pybyd/_api/_common.py) | Thin dispatch: `post_token_json` / `build_inner_base` call overseas builders when `not config.is_china_region`, else import from `cn_envelope` / `login_cn` as needed. Avoid growing `_common.py` with CN logic—delegate to the CN modules. |

Optional later split (only if `cn_envelope.py` gets large): extract `cn_inner.py` for inner payload helpers only; not required for the first iteration.

## 1. Configuration and mode detection

**Add to [`BydConfig`](/src/pybyd/config.py)** (with `from_env` wiring):

- **CN app / brand**: `app_channel` (default `"99"`), `cn_app_version` (e.g. `"9.10.2"`), `cn_app_inner_version` (e.g. `"502"`, also used as HTTP header `version` per `client.js`), `target_brand` / `vehicle_brand` (default `"1"`), `network_operator` (default Unicode “无” like `client.js`), optional `brand_flag` (default `"dynasty"` — `client.js` hardcodes this header even when `target_brand` changes; expose override for future-proofing).
- **Helper**: `is_china_region: bool` — `True` when `cn.byd.auto` appears in `base_url` (same rule as `client.js`), unless you prefer an explicit `BYD_REGION=cn|overseas` override to avoid hostname ambiguity.

**`from_env`**: map `BYD_APP_CHANNEL`, `BYD_CN_APP_VERSION`, `BYD_CN_APP_INNER_VERSION`, `BYD_TARGET_BRAND`, `BYD_VEHICLE_BRAND`, `BYD_NETWORK_OPERATOR`, optional `BYD_BRAND_FLAG` (document alongside existing `BYD_BASE_URL` CN example from README).

## 2. WBSK crypto module (largest engineering item)

**New package** under `src/pybyd/_crypto/`:

- Port [`wbsk.js`](D:/PROJ/PET_PROJ/BYD/BYD-re/wbsk.js) to Python: `parse_wbc_key`, nibble encode/decode, WBC encrypt/decrypt block, nested CBC layers, `encrypt_envelope` / `decrypt_envelope` (Base64 envelope with version byte `0x93`).
- **Embed tables**: vendor [`wbsk_tables.js`](D:/PROJ/PET_PROJ/BYD/BYD-re/wbsk_tables.js) data — prefer a **small generated Python module** or **package data file** loaded at runtime (similar spirit to [`bangcle_tables.bin`](/pyproject.toml) artifacts). Register any new data file in `[tool.hatch.build] artifacts` if not pure Python.
- **Static `WBSK_KEYS`**: copy hex blobs from `wbsk.js` unchanged.
- **Tests**: add `tests/test_wbsk.py` porting the **golden vectors** from [`scripts/test_wbsk.js`](D:/PROJ/PET_PROJ/BYD/BYD-re/scripts/test_wbsk.js) (block encrypt/decrypt, nibble `0x93`, full envelope decrypt + expected outer JSON/checkcode). This de-risks the port without live CN calls.

## 3. Transport layer: codec + CN headers

Refactor [`SecureTransport`](/src/pybyd/_transport.py) to depend on a small **`EnvelopeCodec` protocol** (encode str → wire string, decode wire string → bytes/utf-8 text), implemented by:

- existing `BangcleCodec`
- new `WbskCodec` (stateless wrapper around WBSK encrypt/decrypt)

**Behavior**:

- **Overseas**: unchanged — `{"request": bangcle(...)}` / decode `response`.
- **CN**: same JSON wrapper, but body string is WBSK Base64; add headers exactly as `postSecure` in `client.js`: `version: cn_app_inner_version`, `platform: ANDROID`, `BrandFlag: <brand_flag>`.
- **Lifecycle**: [`BydClient.async_start`](/src/pybyd/client.py) should instantiate the correct codec (Bangcle load tables vs WBSK static init only — no async load unless you mirror Bangcle’s pattern for consistency).

## 4. Checkcode and signing details (CN)

- Add **`compute_cn_checkcode(payload_json: str) -> str`**: full **SHA-256** hex of the JSON string (see README §4 and `computeCnCheckcode` in `client.js`).
- **CN outer payload before WBSK encrypt** follows `addCnDeviceFields`: append `ostype`, `imei`, `mac`, `model`, `sdk`, `mod`, `serviceTime`, then set `checkcode` from **SHA-256 of `json.dumps` of that dict** with **stable field order** matching JS object insertion order (use `sort_keys=False` and build dicts in the same sequence as `client.js`; verify against golden envelope test).
- **Token signing**: CN uses a different `sign_fields` set (no `countryCode` / `language`; adds `appChannel`, `targetBrand`, `vehicleBrand`, `identifierType`, optional `objective` for VIN) — mirror [`buildTokenOuterEnvelope` CN branch](D:/PROJ/PET_PROJ/BYD/BYD-re/client.js) (~399–432).
- **Edge case**: [`build_sign_string`](/src/pybyd/_crypto/signing.py) must stringify values like JS (`String(null)` → `"null"`, integers coerced). Audit CN sign dicts for non-string values (`loginType`, `identifierType`) and normalize to strings before signing.

## 5. Login flow (`login_cn.py`)

**New file [`_api/login_cn.py`](/src/pybyd/_api/login_cn.py)** — do not put CN login logic in [`login.py`](/src/pybyd/_api/login.py):

- `build_cn_login_request` — mirror [`buildCnLoginRequest`](D:/PROJ/PET_PROJ/BYD/BYD-re/client.js): inner fields (`isAuto: "0"`, `osType: "Android"`, `osVersion` from device `os_type`, `devicename` lowercase key, `configVersion`, empty geo/bluetooth, etc.), sign fields (`appChannel`, `loginType: 0`, …), outer without overseas-only fields (`countryCode`, `functionType`, `signKey`).
- `parse_cn_login_response` — CN-specific parsing (endpoint constant `/app/auth/login` for error messages):
  - Accept `token.encryToken` **or** `token.encryptToken` (README).
  - Read `token.superId`, `token.superBindRelationDtoMap[target_brand].userId`; set **`AuthToken.user_id`** to brand user id if present else `superId` (same as `performLogin` in `client.js`).
  - Return an `AuthToken` (or small dataclass) that includes optional **`super_id`** for session construction.

**[`login.py`](/src/pybyd/_api/login.py)**: remains overseas-only; no CN branches inside this file.

**[`models/token.py`](/src/pybyd/models/token.py) / [`Session`](/src/pybyd/session.py)**: add optional `super_id: str | None` on `Session`. Add **`effective_api_identifier`** property: `super_id or user_id` for outer `identifier` and MQTT (matches `session.superId || session.userId` in `client.js`).

**[`BydClient.login`](/src/pybyd/client.py)**: if `config.is_china_region`: `post_secure("/app/auth/login", build_cn_login_request(...))` + `parse_cn_login_response`; else existing overseas path. Error messages must cite the endpoint actually used.

## 6. Token-authenticated envelopes (`cn_envelope.py`)

**New file [`_api/cn_envelope.py`](/src/pybyd/_api/cn_envelope.py)** — do not add CN branches to [`_envelope.py`](/src/pybyd/_api/_envelope.py):

- `build_cn_token_outer_envelope(config, session, inner, now_ms, ...)` → same return shape as overseas: `(outer_dict, content_key)`. Implement the CN branch of [`buildTokenOuterEnvelope`](D:/PROJ/PET_PROJ/BYD/BYD-re/client.js) (~399–432): `sign_fields` without `countryCode`/`language`, `identifier` / `identifierType` / optional `objective`, `appChannel`, `targetBrand`, `vehicleBrand`, then device fields + SHA-256 `checkcode` (via [`compute_cn_checkcode`](/src/pybyd/_crypto/hashing.py) on the exact JSON string `client.js` would produce). Nullable keys must match JS (`null` vs missing) for signing parity.
- `build_cn_inner_base(...)` — mirror CN [`buildInner`](D:/PROJ/PET_PROJ/BYD/BYD-re/client.js) (`deviceName`, `mobileBrand`, `mobileModel`, `networkOperator`, `osType: "Android"`, `osVersion`, `softType`, `version: cn_app_inner_version`, etc.).
- `build_cn_vehicle_list_inner(...)` — `build_cn_inner_base` plus **`appUiName: ""`** (`buildListRequest` in `client.js`).

**[`_envelope.py`](/src/pybyd/_api/_envelope.py)**: overseas path only; unchanged contract.

**[`_common.py`](/src/pybyd/_api/_common.py)**:

- `build_inner_base`: delegate to `build_cn_inner_base` when CN; else existing dict.
- `post_token_json`: call `build_cn_token_outer_envelope` when CN, else `build_token_outer_envelope`. Use `session.effective_api_identifier` anywhere the outer payload needs the CN super-id–aware identifier (replace naive `session.user_id` only where `client.js` uses `superId || userId`).

## 7. Vehicle list

[`fetch_vehicle_list`](/src/pybyd/_api/vehicle.py):

- Endpoint: `/app/auth/getAllListByUserId` when CN.
- Inner: use `build_cn_vehicle_list_inner` from **`cn_envelope.py`** (not ad-hoc dict assembly in `vehicle.py`).
- After decrypt: if dict with `diLinkAutoInfoList`, use that array; else if list, use as today.
- [`Vehicle`](/src/pybyd/models/vehicle.py) already `extra="ignore"` via [`BydBaseModel`](/src/pybyd/models/_base.py); optional follow-up: add aliases for CN-only display fields if you want them typed (not required for core support).

## 8. GPS

- **CN**: single POST to **`/vehicleInfo/gps/locationRequestService`** (no serial polling). Implement either:
  - a dedicated `fetch_gps_cn` helper, or
  - branch inside [`get_gps_info`](/src/pybyd/client.py) / `_trigger_and_poll` to skip poll when `config.is_china_region`.
- [`GpsInfo`](/src/pybyd/models/gps.py) already supports flat `latitude` / `longitude` / `gpsTimeStamp` (as in `status.html`); keep `data` flattening for overseas.

## 9. MQTT bootstrap

Update [`fetch_mqtt_bootstrap` / `_fetch_emq_broker`](/src/pybyd/_mqtt.py):

- **Broker field**: map `target_brand` → `dynastyEmqBroker`, `oceanEmqBroker`, etc. (copy `CN_BROKER_FIELDS` from `client.js`).
- **Client id**: `dynasty_<IMEI_MD5>` (uppercase md5 as today) vs `oversea_`.
- **Topic**: `/dynasty/res/<identifier>` vs `/oversea/res/...`.
- **Username**: `effective_api_identifier` (superId preference on CN).
- **Password formula**: unchanged structure `MD5(signToken + clientId + user + ts)` — use the **same `user` string as MQTT username** (per `buildMqttPassword` / `mqttUserId` in `client.js`).

Inner payload for broker request: `version` must use **CN inner version** when CN (`buildEmqBrokerRequest` in `client.js`).

## 10. Realtime and control endpoints

- **Realtime**: README marks endpoint **same**; [`get_vehicle_realtime`](/src/pybyd/client.py) can keep trigger/poll URLs; CN inner + outer shaping flows through **`cn_envelope.py`** / `_common` dispatch (§6).
- **Remote control / verify PIN**: same paths; ensure **`build_cn_token_outer_envelope`** covers [`_control_api`](/src/pybyd/_api/control.py) payloads (VIN present → `identifierType` 0 and `objective` in sign fields per `client.js`). Mirror `buildVerifyControlPasswordRequest` using **`app_inner_version` for verify inner `version`** (overseas field in `client.js` — keep parity unless you discover CN app differs).

## 11. Tests, documentation, and scripts

### Tests

- **Unit tests**: WBSK vectors (§2); optional test for `compute_cn_checkcode` on a fixed dict vs known SHA-256.
- **Integration-style tests**: mock `post_secure` to return prebuilt outer JSON / skip network.

### Scripts (`scripts/`)

**Yes — update (lightly); no new script is required** for basic CN support. [`dump_all.py`](/scripts/dump_all.py), [`data_diff.py`](/scripts/data_diff.py), and [`generate_api_mapping_tables.py`](/scripts/generate_api_mapping_tables.py) already use `BydConfig.from_env()` + `BydClient`; once the library speaks CN, they work if the user sets `BYD_BASE_URL` (e.g. `https://dilinksuperappserver-cn.byd.auto`) and the CN-related `BYD_*` vars from §1.

**Recommended updates:**

- **Docstrings / Usage** in those three scripts: add a short CN example block (base URL + phone-style username + `BYD_CN_APP_*` / `BYD_TARGET_BRAND` / `BYD_APP_CHANNEL` as needed), mirroring [BYD-re README](D:/PROJ/PET_PROJ/BYD/BYD-re/README.md).
- **[`dump_all.py`](/scripts/dump_all.py)** (optional but useful): at startup, log or print **resolved region** (`is_china_region`) and `base_url` in the text/JSON header so saved dumps are self-describing when comparing overseas vs CN.
- **[`generate_api_mapping_tables.py`](/scripts/generate_api_mapping_tables.py)**: note in the docstring that **raw key sets differ by region**; mapping tables generated against CN are not directly comparable to EU dumps. Optional: write `region: cn|overseas` into generated markdown metadata (from `config.is_china_region`).
- **[`diff_dumps.py`](/scripts/diff_dumps.py)**: **no change** — file-to-file JSON diff only.
- **[`dump_and_diff.sh`](/dump_and_diff.sh)**: optional comment at top reminding that dumps follow whatever `BYD_BASE_URL` / env the shell exports (same session for both dumps in one run).

**Not planned unless you need it later:** a separate `scripts/dump_cn.py`; the generic dump tooling is enough.

### README

- [`pyBYD/README.md`](/README.md): document CN `BYD_BASE_URL`, new env vars, `target_brand` for MQTT broker selection, GPS single-shot behavior, and point the **Scripts** subsection at the CN env example above.

## 12. Risk notes

- **WBSK port correctness** is the main risk; golden tests from `test_wbsk.js` are the primary safety net.
- **`BrandFlag`**: reference client always sends `dynasty`; if non-Dynasty CN apps require a different flag, the planned `brand_flag` override avoids another code change.
- **Token field naming**: always accept both `encryToken` and `encryptToken` when parsing login.
