### PR TITLE
add start_charging endpoint

### DIFF
--- a/references/changeChargeStatue.md
+++ b/references/changeChargeStatue.md
@@ -1,0 +1,163 @@
+# Toggle Smart Charging — `/control/smartCharge/changeChargeStatue`
+
+Captured request/response for toggling the smart-charging switch via the BYD overseas (AU) DiLink API.
+Sensitive values (user IDs, device fingerprints, signatures, ciphertexts, timestamps, VIN) have been replaced with `<…>` placeholders.
+
+## Wire format
+
+The transport layer uses two nested envelopes:
+
+1. **Outer ("Bangcle") envelope** — JSON `{"request": "F<base64>"}`. The `F`-prefixed string is white-box AES-CBC ciphertext (PKCS7, zero IV) decoded against the static `bangcle_tables.bin` table set. Decoding produces the **outer payload** below.
+2. **Inner AES envelope** — the `encryData` (request) / `respondData` (response) hex strings inside the outer payload are AES-128-CBC + PKCS7 + zero IV, keyed by `MD5(session.encry_token)` (see [src/pybyd/_crypto/aes.py](src/pybyd/_crypto/aes.py) and [src/pybyd/session.py:44-58](src/pybyd/session.py#L44-L58)). This per-session key is not recoverable from a packet capture alone.
+
+Reference implementation: [src/pybyd/_transport.py](src/pybyd/_transport.py), [src/pybyd/_api/_envelope.py](src/pybyd/_api/_envelope.py), [src/pybyd/_api/smart_charging.py](src/pybyd/_api/smart_charging.py).
+
+---
+
+## Request
+
+```http
+POST https://dilinkappoversea-au.byd.auto/control/smartCharge/changeChargeStatue HTTP/2.0
+accept-encoding: identity
+content-type: application/json; charset=UTF-8
+user-agent: okhttp/4.12.0
+
+{"request":"F<bangcle-base64-ciphertext>"}
+```
+
+### Outer payload (after Bangcle decoding)
+
+```json
+{
+  "appName": "",
+  "countryCode": "AU",
+  "encryData": "<aes128-cbc-hex of inner JSON, key=MD5(encry_token)>",
+  "identifier": "<user_id>",
+  "imeiMD5": "<MD5(imei)>",
+  "language": "en",
+  "reqTimestamp": "<unix ms>",
+  "sign": "<sha1Mixed of build_sign_string(inner ∪ envelope fields, sign_key)>",
+  "userType": "1",
+  "ostype": "and",
+  "imei": "BANGCLE01234",
+  "mac": "00:00:00:00:00:00",
+  "model": "Redmi Note 9S",
+  "sdk": "30",
+  "serviceTime": "<unix ms>",
+  "mod": "Xiaomi",
+  "checkcode": "<md5 over outer fields>"
+}
+```
+
+Field notes (from [src/pybyd/_api/_envelope.py:53-82](src/pybyd/_api/_envelope.py#L53-L82) and [src/pybyd/config.py:51-60](src/pybyd/config.py#L51-L60)):
+
+| Field | Source | Notes |
+|---|---|---|
+| `appName` | constant `""` | Always empty in this build. |
+| `countryCode` | `BydConfig.country_code` | `"AU"` here; `"NL"` is the package default. |
+| `encryData` | AES-128-CBC of inner JSON | Hex-encoded, uppercase. Key = `MD5(session.encry_token)`. |
+| `identifier` | `Session.user_id` | Returned from login; user-identifying. |
+| `imeiMD5` | `MD5(device.imei)` | Stable per install; identifying. |
+| `language` | `BydConfig.language` | `"en"`. |
+| `reqTimestamp` | `int(time.time()*1000)` | Used in signature. |
+| `sign` | `sha1_mixed(build_sign_string(...))` | HMAC-style signature over inner ∪ outer fields, keyed by `MD5(sign_token)`. |
+| `userType` | `"1"` | Hardcoded for token-auth requests. |
+| `ostype` | `BydDevice.ostype` | `"and"` (Android). |
+| `imei`, `mac`, `model`, `sdk`, `mod` | `BydDevice.*` | Spoofed device fingerprint; defaults shipped in [config.py](src/pybyd/config.py). The captured values match the package defaults except `model="Redmi Note 9S"`/`sdk="30"`, which are user overrides. |
+| `serviceTime` | `int(time.time()*1000)` | Distinct from `reqTimestamp`; not in signature. |
+| `checkcode` | `compute_checkcode(outer)` | MD5 over the outer fields; integrity check. |
+
+### Inner payload (under `encryData`, after AES-CBC decryption)
+
+Verified against a live decryption. Inner JSON keys are sorted alphabetically by the client before encryption:
+
+```json
+{
+  "deviceType": "0",
+  "imeiMD5": "<MD5(imei)>",
+  "networkType": "wifi",
+  "random": "<32 hex chars, secrets.token_hex(16).upper()>",
+  "status": "1",
+  "timeStamp": "<unix ms>",
+  "timeZone": "",
+  "version": "<app_inner_version, e.g. \"333\">",
+  "vin": "<17-char VIN>"
+}
+```
+
+The captured trace (BYD SHARK, AU, 2026-05-01) only contains a `status: "1"` request, followed by `/control/smartCharge/changeResult` polling. The `status: "0"` value is shown in the inner payload above but was not exercised by the captured BYD app session.
+
+> ✅ **Verified:** `status: "1"` reliably starts charging on a plugged-in vehicle (live tested 2026-05-02 against AU; vehicle responds, `changeResult` returns `res: 2 "Operation successful"` within 1–2 polls).
+>
+> ❌ **Verified no-op:** `status: "0"` returned `res: 2 "Operation successful"` from `changeResult` in live testing, but the vehicle kept charging — both with default car settings and after the user adjusted candidate "remote charge control" toggles in the app. The `status: "0"` path does not stop an active charge.
+>
+> 💡 **Probable explanation:** the BYD mobile app has **no in-app stop-charge action** of any kind. The user-facing way to stop an active charge (per BYD documentation and owner experience) is to press the unlock button twice on the key fob or door handle, which signals the BMS to release the charge plug — a physical/CAN-bus path, not a cloud command. The `status` field on this endpoint likely controls something narrower than "start/stop active charge" (e.g. arming the smart-charge schedule for the next session, or a state machine that only activates when the vehicle is in a specific pre-charge state). The cloud accepts `status: "0"` and reports success because the request shape is valid, but no vehicle action follows.
+>
+> **Practical implication:** to programmatically interrupt a charge, the supported path is to manipulate the **smart-charging schedule** via [`/control/smartCharge/saveOrUpdate`](https://github.com/jkaberg/pyBYD/blob/main/src/pybyd/_api/smart_charging.py) — e.g. set `targetSoc` to the current SoC, or set the schedule window into the past. Capture and document the `saveOrUpdate` payload from the app before building this; the existing pyBYD `save_charging_schedule()` is unverified for AU.
+
+> Note: this endpoint appears to accept multiple inner-payload variants. The captured request uses `status` to drive **direct charging control**. The current pyBYD implementation at [src/pybyd/_api/smart_charging.py](src/pybyd/_api/smart_charging.py) `toggle_smart_charging` sends `smartChargeSwitch` instead — that is likely a separate variant for toggling the **smart-charging schedule** (i.e. enabling/disabling the configured schedule rather than starting/stopping a charge), and not interchangeable with the `status` payload documented here. Both variants reuse the standard `build_inner_base()` fields plus `timeZone: ""`; the differentiating field is the variant-specific key (`status` vs `smartChargeSwitch`). A separate capture of the smart-schedule toggle would let us document both shapes definitively.
+
+---
+
+## Response
+
+```http
+HTTP/2.0 200
+date: <RFC1123>
+content-type: application/json
+vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+
+{"response":"F<bangcle-base64-ciphertext>"}
+```
+
+### Outer payload (after Bangcle decoding)
+
+```json
+{
+  "identifier": "<user_id>",
+  "respondData": "<aes128-cbc-hex of inner JSON, key=MD5(encry_token)>",
+  "code": "0",
+  "message": "SUCCESS"
+}
+```
+
+Non-zero `code` triggers exception mapping in [src/pybyd/_api/_common.py:64-107](src/pybyd/_api/_common.py#L64-L107):
+- `"1001"` → endpoint not supported for this VIN.
+- Codes in `SESSION_EXPIRED_CODES` ([src/pybyd/_constants.py](src/pybyd/_constants.py)) → re-login required.
+
+### Inner payload (under `respondData`, after AES-CBC decryption)
+
+Verified against a live decryption:
+
+```json
+{
+  "requestSerial": "<32 hex chars, server-generated correlation token>"
+}
+```
+
+That `requestSerial` is the **only** correlation key for the follow-up [`/control/smartCharge/changeResult`](changeResult.md) poll — clients must capture it from this response and feed it into the next request's inner payload. The current `CommandAck` model ([src/pybyd/models/control.py:102-117](src/pybyd/models/control.py#L102-L117)) drops this field on the floor; a `request_serial` attribute should be added (with `validation_alias="requestSerial"`) for callers that want to poll.
+
+---
+
+## Reproducing the decode
+
+```python
+import json, sys
+sys.path.insert(0, "src")
+from pybyd._crypto.bangcle import BangcleCodec
+
+codec = BangcleCodec()
+
+def decode_outer(env: str) -> dict:
+    text = codec.decode_envelope(env).decode("utf-8")
+    if text.startswith(("F{", "F[")):
+        text = text[1:]
+    return json.loads(text)
+
+# With an active session, decrypt the inner layer too:
+from pybyd._crypto.aes import aes_decrypt_utf8
+inner_plain = aes_decrypt_utf8(outer["encryData"], session.content_key())
+print(json.loads(inner_plain))
+```
+
+Without a captured `encry_token`, the inner `encryData`/`respondData` cannot be recovered from the packet alone — that key is established at login and never leaves the client.

--- a/references/changeResult.md
+++ b/references/changeResult.md
@@ -1,0 +1,243 @@
+# Smart-Charging Result Poll — `/control/smartCharge/changeResult`
+
+Captured request/response sent shortly after `/control/smartCharge/changeChargeStatue`, on the BYD overseas (AU) DiLink API.
+Sensitive values (user IDs, device fingerprints, signatures, ciphertexts, timestamps, VIN, requestSerial) have been replaced with `<…>` placeholders.
+
+This endpoint is **not currently implemented in pyBYD** ([src/pybyd/_api/smart_charging.py](src/pybyd/_api/smart_charging.py) only sends the toggle, never polls for its result). It follows the same `/<command> → /<command>Result` pattern as `/control/remoteControl` + `/control/remoteControlResult` ([src/pybyd/_api/control.py:394-409](src/pybyd/_api/control.py#L394-L409)) and `/vehicleInfo/.../vehicleRealTime{,Result}` ([src/pybyd/_api/realtime.py](src/pybyd/_api/realtime.py)).
+
+In the capture this poll fires **~1.24 s after** the `changeChargeStatue` request (`reqTimestamp` 1777557674040 → 1777557675281), consistent with a one-shot result poll rather than long-running polling.
+
+## Wire format
+
+Identical envelope structure to `changeChargeStatue` — see [changeChargeStatue.md](changeChargeStatue.md#wire-format) for the full Bangcle + AES-CBC layering and key derivation. Only the inner payload and the response body differ.
+
+---
+
+## Request
+
+```http
+POST https://dilinkappoversea-au.byd.auto/control/smartCharge/changeResult HTTP/2.0
+accept-encoding: identity
+content-type: application/json; charset=UTF-8
+user-agent: okhttp/4.12.0
+
+{"request":"F<bangcle-base64-ciphertext>"}
+```
+
+### Outer payload (after Bangcle decoding)
+
+Same fields as the toggle — only the values of `encryData`, `sign`, `reqTimestamp`, `serviceTime`, and `checkcode` change between requests.
+
+```json
+{
+  "appName": "",
+  "countryCode": "AU",
+  "encryData": "<aes128-cbc-hex of inner JSON, key=MD5(encry_token)>",
+  "identifier": "<user_id>",
+  "imeiMD5": "<MD5(imei)>",
+  "language": "en",
+  "reqTimestamp": "<unix ms>",
+  "sign": "<sha1Mixed of build_sign_string(inner ∪ envelope fields, sign_key)>",
+  "userType": "1",
+  "ostype": "and",
+  "imei": "BANGCLE01234",
+  "mac": "00:00:00:00:00:00",
+  "model": "Redmi Note 9S",
+  "sdk": "30",
+  "serviceTime": "<unix ms>",
+  "mod": "Xiaomi",
+  "checkcode": "<md5 over outer fields>"
+}
+```
+
+### Inner payload (under `encryData`, after AES-CBC decryption)
+
+Verified against a live decryption. Inner JSON keys are sorted alphabetically by the client before encryption:
+
+```json
+{
+  "deviceType": "0",
+  "imeiMD5": "<MD5(imei)>",
+  "networkType": "wifi",
+  "random": "<32 hex chars, secrets.token_hex(16).upper()>",
+  "requestSerial": "<32 hex chars, copied verbatim from changeChargeStatue response>",
+  "timeStamp": "<unix ms>",
+  "version": "<app_inner_version, e.g. \"333\">",
+  "vin": "<17-char VIN>"
+}
+```
+
+`build_inner_base()` already accepts a `request_serial` argument ([src/pybyd/_api/_common.py:38-61](src/pybyd/_api/_common.py#L38-L61)) — implementing this endpoint should reuse it the same way [`_fetch_control_endpoint()`](src/pybyd/_api/control.py#L58-L70) does. The serial comes from the toggle's `respondData` ([changeChargeStatue.md](changeChargeStatue.md#response)).
+
+In the capture, the same serial value `EAA3…7CC` appears in (a) the toggle response's `respondData` and (b) this poll's `encryData` `requestSerial` field — confirming the correlation flow.
+
+Note that this poll **does not** include `timeZone`, while the matching `changeChargeStatue` request does. The two endpoints' inner shapes are *not* identical despite both being under `/control/smartCharge/`.
+
+---
+
+## Response
+
+```http
+HTTP/2.0 200
+date: <RFC1123>
+content-type: application/json
+vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+
+{"response":"F<bangcle-base64-ciphertext>"}
+```
+
+### Outer payload (after Bangcle decoding)
+
+```json
+{
+  "identifier": "<user_id>",
+  "respondData": "<aes128-cbc-hex of inner JSON, key=MD5(encry_token)>",
+  "code": "0",
+  "message": "SUCCESS"
+}
+```
+
+`code`/`message` mapping is the standard one ([src/pybyd/_api/_common.py:64-107](src/pybyd/_api/_common.py#L64-L107)).
+
+### Inner payload (under `respondData`, after AES-CBC decryption)
+
+Three response shapes observed, depending on whether and how the underlying change has settled.
+
+**Pending** (returned while the change is still propagating):
+
+```json
+{
+  "res": 1,
+  "language": "en",
+  "userId": "<user_id>"
+}
+```
+
+**Terminal — success** (returned once the toggle has been applied):
+
+```json
+{
+  "res": 2,
+  "message": "Operation successful"
+}
+```
+
+**Terminal — failure** (observed during live testing in two distinct "already in target state" scenarios):
+
+```json
+{
+  "res": 3,
+  "message": "Operation failure"
+}
+```
+
+> ⚠ **Caveat:** the cloud's `res` does **not** reliably reflect actual vehicle state changes. During live testing a `status: "0"` (intended stop) request returned `res: 2 "Operation successful"` but the vehicle kept charging — and per [`changeChargeStatue.md`](changeChargeStatue.md#L88) the BYD app has no in-app stop-charge action at all, so the `status: "0"` flow appears to be a cloud-only no-op. So `res: 2` is at best an "accepted by cloud" signal, not a guarantee that the action took effect.
+>
+> `res: 3` ("Operation failure") has now been observed twice, both consistent with "vehicle already in target state":
+> 1. A back-to-back duplicate `status: "1"` (start) request while a previous start was still settling.
+> 2. A `status: "1"` (start) request issued while the battery was already at 100% SoC (nothing to charge).
+>
+> Treat `res: 3` as a soft-reject that callers should surface as a friendly "already in target state / nothing to do" rather than a hard error.
+
+Field semantics:
+
+| Field | Type | Notes |
+|---|---|---|
+| `res` | int | State code. **`1` = pending / still in progress** — keep polling. **`2` = terminal "success"** — cloud accepted the request, but see caveat above. **`3` = terminal "failure"** — observed twice, both consistent with "already in target state" (duplicate start; start while at 100% SoC). Treat any `res` other than 1/2 as failure for client-side error handling. |
+| `message` | str | Only present on terminal responses (`res != 1`). Captured values are the literal strings `"Operation successful"` and `"Operation failure"`. Callers should match `res`, not `message`, since the string is locale-dependent (the inner request carries no `language`, so this string appears to come from the user's account/profile language). |
+| `language` | str | Only present in pending responses. Echoes the session language. |
+| `userId` | str | Only present in pending responses. Echoes the account user id. |
+
+Notably absent: there is **no `requestSerial` echo** in either response shape, despite it being the correlation key in the request. Callers must track the serial themselves.
+
+### Polling behaviour
+
+In the capture this endpoint was hit **5 times** by the official client (the user originally recalled "6 in total"; the log shows 5):
+
+| Poll # | `reqTimestamp` (ms) | Δ from toggle | `res` |
+|---|---|---|---|
+| toggle (`changeChargeStatue`) | 1777557674040 | — | (returns `requestSerial`) |
+| 1 | 1777557675281 | +1.24 s | `1` (pending) |
+| 5 | 1777557683473 | +9.43 s | `2` (terminal, `message: "Operation successful"`) |
+
+Polls 2–4 weren't captured in the log, but the spacing implies ~2 s between attempts. All polls reuse the **same `requestSerial`** with a fresh `random` and `timeStamp` per request.
+
+After the terminal `res: 2`, the client immediately fires `/control/smartCharge/homePage` (Δ +9.71 s from the toggle, +0.28 s after the terminal poll) to refresh the UI with the now-current smart-charging state — that is a separate endpoint and not part of this control flow.
+
+This matches the polling pattern used by [`_execute_remote_control_with_polling()`](src/pybyd/_api/control.py#L394-L447):
+- ~2 s `poll_interval` between attempts.
+- A `poll_attempts` cap of around 5–6.
+- A "ready" check that succeeds when `res == 2` (continue while `res == 1`).
+- `res == 3` has been observed twice with `message: "Operation failure"`: once on a back-to-back duplicate start, and once on a start request while the battery was already at 100% SoC. Both observations are consistent with "vehicle already in target state". Treat as `BydRemoteControlError` but consider surfacing a friendlier message at the UI seam.
+- Any other `res` value, or exhausting attempts with `res == 1`, should also be treated as failure (`BydRemoteControlError`).
+
+Open questions to resolve with more captures:
+- ~~What does `status: "0"` actually do?~~ **Answered, mostly:** the BYD app has no in-app stop-charge button, and live testing confirms `status: "0"` is a cloud-side no-op for an active charge. To programmatically interrupt a charge, capture and use the smart-charging schedule update path (`/control/smartCharge/saveOrUpdate`) — e.g. set `targetSoc` to current SoC.
+- Are there vehicle-state failure causes (offline, comms error, charger fault) that produce a different `res` or message?
+- ~~Confirm `res: 3` semantics — is it "already in target state", or a more general "vehicle rejected"?~~ **Two observations now, both "already in target state" (duplicate start, and 100% SoC start). Hypothesis is well supported but not exhaustively proven** — there could still be other vehicle-side rejects that also surface as `res: 3`.
+
+---
+
+## Implementing in pyBYD
+
+This needs three coordinated changes:
+
+1. **[`build_inner_base()`](src/pybyd/_api/_common.py#L38-L61)** — emit `timeZone: ""` for the toggle path. (The result poll does *not* carry `timeZone`, so the field must be optional, matching how `vin`/`requestSerial` are already optional.)
+2. **[`toggle_smart_charging()`](src/pybyd/_api/smart_charging.py#L20-L52)** — rename `smartChargeSwitch` → `status` (current code is sending an unrecognised key), and capture the `requestSerial` returned in `respondData` so the caller can poll.
+3. **New `get_smart_charging_result()`** in `smart_charging.py`, modelled on [`_fetch_control_endpoint()`](src/pybyd/_api/control.py#L58-L70) + [`_execute_remote_control_with_polling()`](src/pybyd/_api/control.py#L394-L447):
+
+```python
+_RESULT_ENDPOINT = "/control/smartCharge/changeResult"
+
+async def _poll_smart_charge_result(
+    config: BydConfig,
+    session: Session,
+    transport: Transport,
+    vin: str,
+    *,
+    request_serial: str,
+    poll_attempts: int = 6,
+    poll_interval: float = 2.0,
+) -> dict[str, Any]:
+    """Poll /control/smartCharge/changeResult until res == 2 (terminal), or attempts exhausted."""
+    last: dict[str, Any] = {}
+    for attempt in range(1, poll_attempts + 1):
+        if attempt > 1:
+            await asyncio.sleep(poll_interval)
+
+        inner = build_inner_base(config, vin=vin, request_serial=request_serial)
+        last = await post_token_json(
+            endpoint=_RESULT_ENDPOINT,
+            config=config,
+            session=session,
+            transport=transport,
+            inner=inner,
+            vin=vin,
+            not_supported_codes=ENDPOINT_NOT_SUPPORTED_CODES,
+        ) or {}
+
+        res = last.get("res")
+        if res == 2:
+            return last  # terminal — inspect last["message"] if needed
+        if res != 1:  # anything other than pending → unexpected/failure
+            raise BydRemoteControlError(
+                f"smartCharge changeResult res={res}",
+                code=str(res),
+                endpoint=_RESULT_ENDPOINT,
+            )
+    # Exhausted attempts while still pending → treat as timeout/failure
+    raise BydRemoteControlError(
+        "smartCharge changeResult timed out (res stayed at 1)",
+        code="timeout",
+        endpoint=_RESULT_ENDPOINT,
+    )
+```
+
+Then `toggle_smart_charging()` should chain the two:
+
+```python
+ack = await _toggle(...)              # returns requestSerial
+result = await _poll_smart_charge_result(..., request_serial=ack.request_serial)
+```
+
+`CommandAck` ([src/pybyd/models/control.py:102-117](src/pybyd/models/control.py#L102-L117)) needs a `request_serial: str | None = Field(default=None, validation_alias="requestSerial")` field added to surface the serial to callers.

--- a/src/pybyd/_api/smart_charging.py
+++ b/src/pybyd/_api/smart_charging.py
@@ -1,11 +1,16 @@
 """Smart charging control endpoints.
 
 Endpoints:
-  - /control/smartCharge/changeChargeStatue  (toggle on/off)
+  - /control/smartCharge/changeChargeStatue  (toggle on/off, or start/stop charge)
+  - /control/smartCharge/changeResult        (poll until status change settles)
   - /control/smartCharge/saveOrUpdate        (save schedule)
 """
 
 from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from pybyd._api._common import ENDPOINT_NOT_SUPPORTED_CODES, build_inner_base, post_token_json
 from pybyd._transport import Transport
@@ -14,7 +19,10 @@ from pybyd.models.control import CommandAck
 from pybyd.session import Session
 
 _TOGGLE_ENDPOINT = "/control/smartCharge/changeChargeStatue"
+_RESULT_ENDPOINT = "/control/smartCharge/changeResult"
 _SAVE_ENDPOINT = "/control/smartCharge/saveOrUpdate"
+
+_logger = logging.getLogger(__name__)
 
 
 async def toggle_smart_charging(
@@ -50,6 +58,111 @@ async def toggle_smart_charging(
     )
     raw = decoded if isinstance(decoded, dict) else {}
     return CommandAck.model_validate({"vin": vin, **raw, "raw": raw})
+
+
+async def trigger_charge_change(
+    config: BydConfig,
+    session: Session,
+    transport: Transport,
+    vin: str,
+    *,
+    start: bool,
+) -> tuple[dict[str, Any], str | None]:
+    """POST ``/control/smartCharge/changeChargeStatue`` to start/stop charging.
+
+    The toggle inner-payload always carries an empty ``timeZone`` (per the
+    captured BYD-app traffic — see ``references/changeChargeStatue.md``).
+    No other endpoint we implement uses this field, so it lives here
+    rather than in the shared ``build_inner_base``.
+
+    Returns ``(raw_response, request_serial)``.  The ``requestSerial`` is
+    needed to correlate the follow-up MQTT push or ``changeResult`` poll.
+    """
+    inner = build_inner_base(config, vin=vin)
+    inner["timeZone"] = ""
+    inner["status"] = "1" if start else "0"
+    decoded = await post_token_json(
+        endpoint=_TOGGLE_ENDPOINT,
+        config=config,
+        session=session,
+        transport=transport,
+        inner=inner,
+        vin=vin,
+        not_supported_codes=ENDPOINT_NOT_SUPPORTED_CODES,
+    )
+    raw = decoded if isinstance(decoded, dict) else {}
+    return raw, raw.get("requestSerial")
+
+
+async def poll_charge_result(
+    config: BydConfig,
+    session: Session,
+    transport: Transport,
+    vin: str,
+    request_serial: str,
+) -> tuple[dict[str, Any], str | None]:
+    """POST ``/control/smartCharge/changeResult`` to check toggle progress.
+
+    Returns ``(raw_response, request_serial)``.  Caller (typically
+    :meth:`BydClient._trigger_and_poll`) inspects ``raw["res"]``: ``1`` =
+    still pending, ``2`` = success terminal, anything else = failure
+    terminal.
+    """
+    inner = build_inner_base(config, vin=vin, request_serial=request_serial)
+    decoded = await post_token_json(
+        endpoint=_RESULT_ENDPOINT,
+        config=config,
+        session=session,
+        transport=transport,
+        inner=inner,
+        vin=vin,
+        not_supported_codes=ENDPOINT_NOT_SUPPORTED_CODES,
+    )
+    raw = decoded if isinstance(decoded, dict) else {}
+    _logger.debug(
+        "smartCharge changeResult vin=%s res=%s message=%s",
+        vin,
+        raw.get("res"),
+        raw.get("message"),
+    )
+    return raw, raw.get("requestSerial") or request_serial
+
+
+def make_change_charge_fetch_fn(*, start: bool) -> Callable[..., Awaitable[tuple[dict[str, Any], str | None]]]:
+    """Adapter: select :func:`trigger_charge_change` or :func:`poll_charge_result`
+    based on the endpoint URL :meth:`BydClient._trigger_and_poll` calls us with.
+
+    The two operations have different inner-payload shapes (trigger needs
+    ``status``/``timeZone``; poll needs ``requestSerial``), so a single
+    generic ``fetch_fn`` like :func:`pybyd._api.realtime.fetch_realtime_endpoint`
+    doesn't apply — we dispatch to the right helper at the seam.
+    """
+
+    async def _fetch(
+        endpoint: str,
+        config: BydConfig,
+        session: Session,
+        transport: Transport,
+        vin: str,
+        request_serial: str | None = None,
+    ) -> tuple[dict[str, Any], str | None]:
+        if endpoint == _RESULT_ENDPOINT:
+            return await poll_charge_result(config, session, transport, vin, request_serial or "")
+        return await trigger_charge_change(config, session, transport, vin, start=start)
+
+    return _fetch
+
+
+def is_charge_change_ready(payload: dict[str, Any]) -> bool:
+    """Predicate for :meth:`BydClient._trigger_and_poll`'s ``is_ready``.
+
+    The trigger response carries only ``requestSerial`` (not ready).
+    The result/MQTT-push response carries ``res``: ``1`` = pending (keep
+    polling), ``2`` = success (terminal, ready), other values = failure
+    (also terminal — surface to the caller, who decides whether to raise).
+    """
+    res = payload.get("res")
+    return isinstance(res, int) and res != 1
 
 
 async def save_charging_schedule(

--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -37,6 +37,7 @@ from pybyd._capabilities.windows import WindowsCapability
 from pybyd._state_engine import ProjectionSpec, VehicleSnapshot, VehicleStateEngine
 from pybyd.exceptions import BydRemoteControlError
 from pybyd.models.charging import ChargingStatus
+from pybyd.models.control import ChargeChangeResult
 from pybyd.models.energy import EnergyConsumption
 from pybyd.models.gps import GpsInfo
 from pybyd.models.hvac import HvacStatus
@@ -213,6 +214,18 @@ class BydCar:
         data = await self._client.get_charging_status(self._vin)
         await self._engine.update_charging(data)
         return data
+
+    async def start_charging(self) -> ChargeChangeResult:
+        """Start charging immediately and wait for the toggle to settle.
+
+        Routes through the BydClient ``_trigger_and_poll`` pipeline:
+        prefers the BYD MQTT ``smartCharge`` push for the result and
+        falls back to ``/control/smartCharge/changeResult`` polling.
+
+        Raises :class:`BydRemoteControlError` if the toggle reports
+        failure or doesn't settle within the polling window.
+        """
+        return await self._client.start_charging(self._vin)
 
     async def update_energy(self) -> EnergyConsumption:
         """Fetch fresh energy consumption data and merge into state engine."""

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -34,6 +34,7 @@ from pybyd.exceptions import (
     BydDataUnavailableError,
     BydEndpointNotSupportedError,
     BydError,
+    BydRemoteControlError,
     BydSessionExpiredError,
 )
 from pybyd.models._base import BydBaseModel
@@ -41,6 +42,7 @@ from pybyd.models.charging import ChargingStatus
 from pybyd.models.command_gating import evaluate_command_gate
 from pybyd.models.control import (
     BatteryHeatParams,
+    ChargeChangeResult,
     ClimateScheduleParams,
     ClimateStartParams,
     CommandAck,
@@ -1321,6 +1323,85 @@ class BydClient:
     async def toggle_smart_charging(self, vin: str, *, enable: bool) -> CommandAck:
         """Enable or disable smart charging."""
         return await self._authed_call(_smart_api.toggle_smart_charging, vin, enable=enable)
+
+    async def start_charging(
+        self,
+        vin: str,
+        *,
+        mqtt_timeout: float | None = None,
+        poll_attempts: int = 6,
+        poll_interval: float = 2.0,
+    ) -> ChargeChangeResult:
+        """Start charging immediately and wait for the toggle to settle.
+
+        Gates on ``functionNo "1012"`` (BYD's ``RESERVATIONCHARGING``
+        capability flag) — raises :class:`BydEndpointNotSupportedError`
+        for vehicles whose ``cfFixedList`` doesn't include it.
+
+        Routes through :meth:`_trigger_and_poll`: triggers
+        ``/control/smartCharge/changeChargeStatue`` with ``status: "1"``,
+        then prefers the BYD MQTT ``smartCharge`` push for the result and
+        falls back to ``/control/smartCharge/changeResult`` HTTP polling
+        if the push doesn't arrive within *mqtt_timeout*.
+
+        Returns the terminal :class:`ChargeChangeResult` (``res == 2``).
+        Raises :class:`BydRemoteControlError` for terminal failures
+        (``res > 2``) or if neither MQTT nor polling produced a terminal
+        result within the polling window.
+        """
+        capabilities = await self.get_vehicle_capabilities(vin)
+        gate = evaluate_command_gate(RemoteCommand.START_CHARGE, capabilities)
+        if not gate.supported:
+            raise BydEndpointNotSupportedError(
+                (f"start_charging blocked for VIN {vin}: " f"gate={gate.gate_id} reason={gate.reason}"),
+                code="command_gate_blocked",
+                endpoint="/control/smartCharge/changeChargeStatue",
+            )
+
+        async def _call() -> ChargeChangeResult:
+            result = await self._trigger_and_poll(
+                vin=vin,
+                trigger_endpoint="/control/smartCharge/changeChargeStatue",
+                poll_endpoint="/control/smartCharge/changeResult",
+                fetch_fn=_smart_api.make_change_charge_fetch_fn(start=True),
+                is_ready=_smart_api.is_charge_change_ready,
+                model_cls=ChargeChangeResult,
+                label="ChargeStart",
+                mqtt_event_type="smartCharge",
+                mqtt_timeout=mqtt_timeout,
+                poll_attempts=poll_attempts,
+                poll_interval=poll_interval,
+            )
+            res = result.res
+            if res == 2:
+                return result
+            if res is None:
+                raise BydRemoteControlError(
+                    "smartCharge change_charge_status timed out without a terminal result",
+                    code="timeout",
+                    endpoint="/control/smartCharge/changeResult",
+                )
+            # res=3 has only ever been observed when the cloud appears to
+            # consider the vehicle "already in target state" — e.g. duplicate
+            # start request, or start_charging while already at maximum SoC.
+            # Surface the likely cause so HA users see something more useful
+            # than the locale-dependent "Operation failure" string.
+            if res == 3:
+                raise BydRemoteControlError(
+                    f"smartCharge change_charge_status rejected by cloud (res=3, "
+                    f"message={result.message!r}) — vehicle is likely already in "
+                    "the target state (already charging, at maximum SoC, or a "
+                    "duplicate start request)",
+                    code="3",
+                    endpoint="/control/smartCharge/changeResult",
+                )
+            raise BydRemoteControlError(
+                f"smartCharge change_charge_status unexpected res={res} message={result.message}",
+                code=str(res),
+                endpoint="/control/smartCharge/changeResult",
+            )
+
+        return await self._call_with_reauth(_call)
 
     async def rename_vehicle(self, vin: str, *, name: str) -> CommandAck:
         """Rename a vehicle."""

--- a/src/pybyd/models/command_gating.py
+++ b/src/pybyd/models/command_gating.py
@@ -133,6 +133,16 @@ _COMMAND_GATE_RULES: tuple[CommandGateRule, ...] = (
             "requiredFunctionNos": ["10300002"],
         }
     ),
+    CommandGateRule.model_validate(
+        {
+            # `1012` is the BYD app's `RESERVATIONCHARGING` capability flag —
+            # the same gate that controls the smart-charging schedule UI.
+            # Cars without it can't accept ``/control/smartCharge/*`` calls.
+            "gateId": "start_charge",
+            "command": RemoteCommand.START_CHARGE,
+            "requiredFunctionNos": ["1012"],
+        }
+    ),
 )
 
 # Seat command requires explicit target selection via control_params.chairType.

--- a/src/pybyd/models/control.py
+++ b/src/pybyd/models/control.py
@@ -37,6 +37,13 @@ class RemoteCommand(enum.StrEnum):
     CLOSE_WINDOWS = "CLOSEWINDOW"
     SEAT_CLIMATE = "VENTILATIONHEATING"
     BATTERY_HEAT = "BATTERYHEAT"
+    # `START_CHARGE` is a synthetic value (never sent on the wire as a
+    # `commandType`).  The on-the-wire smart-charging "start" toggle goes via
+    # `/control/smartCharge/changeChargeStatue` with ``status: "1"`` rather
+    # than `/control/remoteControl`.  We add the enum member so the gating
+    # table can express the `functionNo` requirement (``1012``) for callers
+    # that introspect command availability.
+    START_CHARGE = "SMARTCHARGESTART"
 
 
 class ControlState(enum.IntEnum):
@@ -104,6 +111,7 @@ class CommandAck(BydBaseModel):
 
     vin: str = ""
     result: str | None = None
+    request_serial: str | None = Field(default=None, validation_alias="requestSerial")
 
     @model_validator(mode="before")
     @classmethod
@@ -114,6 +122,36 @@ class CommandAck(BydBaseModel):
         r = values.get("result")
         if r is not None and not isinstance(r, str):
             values = {**values, "result": None}
+        return values
+
+
+class ChargeChangeResult(BydBaseModel):
+    """Terminal result of ``/control/smartCharge/changeChargeStatue``.
+
+    Returned by :meth:`BydClient.start_charging` once the change has settled
+    — either via the MQTT ``smartCharge`` push that BYD's cloud sends back,
+    or via the ``/control/smartCharge/changeResult`` HTTP poll fallback.
+
+    See ``references/changeResult.md`` for the captured payload shape.
+    """
+
+    vin: str = ""
+    res: int | None = None
+    """BYD ``res`` code: ``1`` = pending (still in progress, keep polling),
+    ``2`` = success (terminal), other values (e.g. ``3``) = failure."""
+    message: str | None = None
+    """Locale-dependent human-readable message (e.g. ``"Operation
+    successful"``).  Use :attr:`res` for branching, not this string."""
+    request_serial: str | None = Field(default=None, validation_alias="requestSerial")
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _capture_raw(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+        if "raw" not in values:
+            values = {**values, "raw": {k: v for k, v in values.items() if k != "raw"}}
         return values
 
 


### PR DESCRIPTION
## Summary

Adds an immediate-charge-start path via the existing `/control/smartCharge/changeChargeStatue` toggle, with the terminal result settled via the BYD `smartCharge` MQTT push (preferred) and a `/control/smartCharge/changeResult` HTTP poll as fallback. Verified end-to-end against AU on a BYD SHARK.

**Public API:** `BydClient.start_charging(vin)` and `BydCar.start_charging()`. Both trigger the toggle, await settlement, and return the terminal `ChargeChangeResult` (`res=2`), or raise `BydRemoteControlError` on timeout / unexpected `res`. Vehicles whose capability list lacks functionNo `1012` (`RESERVATIONCHARGING`) raise `BydEndpointNotSupportedError` before any request goes out.

## Changes

- `client.py` — `BydClient.start_charging()` routes through `_trigger_and_poll` with `mqtt_event_type="smartCharge"` so the MQTT push wins when it arrives in time; HTTP polling of `changeResult` is only used as a fallback. Maps terminal codes to typed results, with a special-cased friendlier message for `res=3` ("already in target state").
- `car.py` — `BydCar.start_charging()` thin wrapper.
- `_api/smart_charging.py` — split into `trigger_charge_change()` (posts `status:"1"|"0"` and returns `requestSerial`) and `poll_charge_result()` (polls `changeResult` until `res != 1`), plus `make_change_charge_fetch_fn()` / `is_charge_change_ready()` adapters that the trigger-and-poll helper dispatches through. The toggle's required `timeZone:""` field is inlined here rather than living in shared `build_inner_base`.
- `models/control.py` — adds `ChargeChangeResult` (`vin`, `res`, `message`, `request_serial`, `raw`); `RemoteCommand.START_CHARGE` synthetic enum member so the gating table can express the `1012` requirement; `CommandAck.request_serial`.
- `models/command_gating.py` — adds the `start_charge` rule requiring functionNo `1012` (`RESERVATIONCHARGING`, the same flag that controls the smart-charging schedule UI in BYD's app).
- `references/changeChargeStatue.md`, `references/changeResult.md` — captured wire formats, polling cadence, and live-test findings (including both observed `res=3` scenarios).

## Caveats

- `status:"1"` (start) is verified. `status:"0"` (stop) is **not** included as a public method — live testing showed it returns `res:2 "Operation successful"` but does not actually stop charging, and the BYD mobile app appears to have no in-app stop-charge action either.
- `res=3` ("Operation failure") has been observed in two distinct scenarios, both consistent with "vehicle already in target state": a back-to-back duplicate start request, and a start request issued at 100% SoC. Treated as `BydRemoteControlError` with a clarifying message rather than a hard failure.

## Test plan

- [x] `start_charging` against AU on a plugged-in BYD SHARK — terminal `res:2` settles in ~2 s via MQTT push
- [x] `start_charging` at 100% SoC — surfaces the friendlier `res=3` "already in target state" error
- [x] Existing test suite passes
- [ ] Maintainer test against EU