### PR TITLE
remove stale TestApplyRealtimeDoorZeroDrop test class

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -11,7 +11,7 @@ from pybyd._validators import (
     guard_gps_coordinates,
 )
 from pybyd.models.gps import GpsInfo
-from pybyd.models.realtime import DoorOpenState, LockState, VehicleRealtimeData
+from pybyd.models.realtime import LockState, VehicleRealtimeData
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -382,66 +382,3 @@ class TestApplyRealtimePreserveWhenNone:
         filtered = apply_realtime_filters(previous, incoming)
 
         assert getattr(filtered, field_name) == incoming_value
-
-
-class TestApplyRealtimeDoorZeroDrop:
-    """Door/trunk/frunk fields follow zero-drop policy for CLOSED (0)."""
-
-    @pytest.mark.parametrize(
-        "field_name",
-        [
-            "left_front_door",
-            "right_front_door",
-            "left_rear_door",
-            "right_rear_door",
-            "trunk_lid",
-            "sliding_door",
-            "forehold",
-        ],
-    )
-    def test_closed_incoming_door_keeps_previous(self, field_name: str) -> None:
-        previous = VehicleRealtimeData.model_validate({field_name: DoorOpenState.OPEN})
-        incoming = VehicleRealtimeData.model_validate({field_name: DoorOpenState.CLOSED})
-
-        filtered = apply_realtime_filters(previous, incoming)
-
-        assert getattr(filtered, field_name) == DoorOpenState.OPEN
-
-    @pytest.mark.parametrize(
-        "field_name",
-        [
-            "left_front_door",
-            "right_front_door",
-            "left_rear_door",
-            "right_rear_door",
-            "trunk_lid",
-            "sliding_door",
-            "forehold",
-        ],
-    )
-    def test_closed_incoming_door_without_previous_dropped(self, field_name: str) -> None:
-        incoming = VehicleRealtimeData.model_validate({field_name: DoorOpenState.CLOSED})
-
-        filtered = apply_realtime_filters(None, incoming)
-
-        assert getattr(filtered, field_name) is None
-
-    @pytest.mark.parametrize(
-        "field_name",
-        [
-            "left_front_door",
-            "right_front_door",
-            "left_rear_door",
-            "right_rear_door",
-            "trunk_lid",
-            "sliding_door",
-            "forehold",
-        ],
-    )
-    def test_open_incoming_door_replaces_previous(self, field_name: str) -> None:
-        previous = VehicleRealtimeData.model_validate({field_name: DoorOpenState.CLOSED})
-        incoming = VehicleRealtimeData.model_validate({field_name: DoorOpenState.OPEN})
-
-        filtered = apply_realtime_filters(previous, incoming)
-
-        assert getattr(filtered, field_name) == DoorOpenState.OPEN


### PR DESCRIPTION
## Summary

Door fields were intentionally removed from `_ZERO_DROP_FIELD_NAMES` in `5dbd816` ("remove doors") and `40d4272` ("do not filter trunk and frunk"), but the matching test class wasn't updated and has been failing on every CI run since.

## Changes

Removed `TestApplyRealtimeDoorZeroDrop` from `tests/test_validators.py`:
- `test_closed_incoming_door_keeps_previous` — asserted CLOSED→OPEN preservation that no longer happens
- `test_closed_incoming_door_without_previous_dropped` — asserted CLOSED is dropped, no longer the case
- `test_open_incoming_door_replaces_previous` — passes, but is the trivial "incoming wins" path (covered implicitly)

Also dropped the now-unused `DoorOpenState` import.

## Test plan

- [x] `pytest tests/` — 97 passed, 0 failed
- [x] `black --check src/ tests/` clean
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/pybyd` clean