### PR TITLE
add capability registry + 19 newly mapped functionNos

### DIFF
--- a/src/pybyd/models/latest_config.py
+++ b/src/pybyd/models/latest_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 from pydantic import Field
 
@@ -10,6 +11,73 @@ from pybyd.models._base import BydBaseModel
 from pybyd.models.command_gating import known_command_function_nos
 
 _NON_ALNUM_RE = re.compile(r"[^A-Z0-9]")
+
+
+@dataclass(frozen=True)
+class FeatureSpec:
+    """One row in the capability registry.
+
+    Maps a capability flag (used by integrations to gate entity creation)
+    to the BYD ``functionNo`` value(s) that signal whether the vehicle
+    supports it.  ``category`` distinguishes user-visible categories so
+    the integration can group entries (e.g. "command" vs "diagnostic").
+    """
+
+    key: str
+    name: str
+    function_nos: tuple[str, ...]
+    category: str
+    description: str = ""
+
+
+# Single source of truth for "feature key → BYD functionNo(s) → human label".
+# When BYD adds new functionNos to overseas firmware, append rows here and
+# the diagnostic sensor / capability gating updates automatically.
+FEATURE_REGISTRY: tuple[FeatureSpec, ...] = (
+    # Direct-control commands.
+    FeatureSpec("lock", "Lock doors", ("1005",), "command"),
+    FeatureSpec("unlock", "Unlock doors", ("1006",), "command"),
+    FeatureSpec("climate", "Climate (HVAC)", ("1001", "10300001"), "command"),
+    FeatureSpec("car_on", "Car on / one-tap prep", ("1001", "10300001"), "command"),
+    FeatureSpec("battery_heat", "Battery heating", ("10300002",), "command"),
+    FeatureSpec("steering_wheel_heat", "Steering-wheel heat", ("10030010", "10300004"), "command"),
+    FeatureSpec("driver_seat_heat", "Driver seat heat", ("10030002", "10300003"), "command"),
+    FeatureSpec("driver_seat_ventilation", "Driver seat ventilation", ("10030001", "10300003"), "command"),
+    FeatureSpec("passenger_seat_heat", "Passenger seat heat", ("10030005", "10300003"), "command"),
+    FeatureSpec("passenger_seat_ventilation", "Passenger seat ventilation", ("10030004", "10300003"), "command"),
+    FeatureSpec("rear_left_seat_heat", "Rear left seat heat", ("10030007",), "command"),
+    FeatureSpec("rear_right_seat_heat", "Rear right seat heat", ("10030009",), "command"),
+    FeatureSpec("find_car", "Find car (horn + lights)", ("1007",), "command"),
+    FeatureSpec("flash_lights", "Flash lights", ("1008",), "command"),
+    FeatureSpec("close_windows", "Close windows", ("1026",), "command"),
+    FeatureSpec("open_windows", "Open windows (vent)", ("1026",), "command"),
+    FeatureSpec("location", "Vehicle location (GPS)", ("1014",), "metadata"),
+    FeatureSpec("start_charge", "Start charging", ("1012",), "command"),
+    FeatureSpec("stop_charge", "Stop charging", ("1012",), "command"),
+    FeatureSpec("open_trunk", "Open trunk", ("1020",), "command"),
+    FeatureSpec("close_trunk", "Close trunk", ("1021",), "command"),
+    FeatureSpec("one_click_shutdown", "Shut car off", ("1031",), "command"),
+    # Informational / sensor capabilities.
+    FeatureSpec("child_presence_detection", "Child presence detection (CPD)", ("1009",), "sensor"),
+    FeatureSpec("digital_key", "Digital key", ("1013",), "metadata"),
+    FeatureSpec("nfc_key_3c", "NFC key (3C)", ("10130002",), "metadata"),
+    FeatureSpec("energy_analysis", "Energy analysis", ("1022",), "sensor"),
+    FeatureSpec("vehicle_health", "Vehicle health summary", ("1023",), "sensor"),
+    FeatureSpec("health_tpms", "Health: tire pressure system", ("10230001",), "sensor"),
+    FeatureSpec("health_steering", "Health: steering system", ("10230002",), "sensor"),
+    FeatureSpec("health_srs", "Health: SRS (airbag)", ("10230003",), "sensor"),
+    FeatureSpec("health_powertrain", "Health: powertrain", ("10230004",), "sensor"),
+    FeatureSpec("health_battery", "Health: power battery", ("10230005",), "sensor"),
+    FeatureSpec("health_esp", "Health: ESP", ("10230007",), "sensor"),
+    FeatureSpec("health_charging", "Health: charging system", ("10230010",), "sensor"),
+    FeatureSpec("health_braking", "Health: parking brake", ("10230011",), "sensor"),
+    FeatureSpec("health_abs", "Health: ABS", ("10230012",), "sensor"),
+)
+
+
+def _registry_function_nos() -> set[str]:
+    """All function_nos referenced by FEATURE_REGISTRY rows."""
+    return {fn for spec in FEATURE_REGISTRY for fn in spec.function_nos}
 
 
 def registered_latest_config_function_nos() -> frozenset[str]:
@@ -26,6 +94,7 @@ def registered_latest_config_function_nos() -> frozenset[str]:
     """
     return frozenset(
         set(known_command_function_nos())
+        | _registry_function_nos()
         | {
             "1002",  # door/window (parent)
             "1003",  # ventilation/heating (parent)
@@ -83,11 +152,24 @@ class VehicleLatestConfig(BydBaseModel):
 
 
 class VehicleCapabilities(BydBaseModel):
-    """Normalized vehicle capability availability used by integrations."""
+    """Normalized vehicle capability availability used by integrations.
+
+    Each capability is a tri-state ``bool | None``: ``True`` if the
+    vehicle's ``getLatestConfig`` lists the required functionNo(s),
+    ``False`` if the lookup ran and the functionNo was absent, and
+    ``None`` only when capability resolution itself failed
+    (see :meth:`unknown`).
+
+    The full set of supported features and the BYD ``functionNo`` values
+    they map to lives in :data:`FEATURE_REGISTRY`.  Adding a new BYD
+    feature is a single-line change there — both the model field and
+    the diagnostic surface pick it up automatically.
+    """
 
     vin: str = ""
     source: str = "latest_config"
 
+    # Core remote-control commands (existing, retained for backwards compat).
     lock: bool | None = None
     unlock: bool | None = None
     climate: bool | None = None
@@ -99,6 +181,8 @@ class VehicleCapabilities(BydBaseModel):
     driver_seat_ventilation: bool | None = None
     passenger_seat_heat: bool | None = None
     passenger_seat_ventilation: bool | None = None
+    rear_left_seat_heat: bool | None = None
+    rear_right_seat_heat: bool | None = None
 
     find_car: bool | None = None
     flash_lights: bool | None = None
@@ -107,6 +191,26 @@ class VehicleCapabilities(BydBaseModel):
     location: bool | None = None
     open_trunk: bool | None = None
     close_trunk: bool | None = None
+
+    # Newly mapped — let integrations gate entities on these instead of
+    # leaving them in ``unknown_function_nos``.
+    start_charge: bool | None = None
+    stop_charge: bool | None = None
+    one_click_shutdown: bool | None = None
+    child_presence_detection: bool | None = None
+    digital_key: bool | None = None
+    nfc_key_3c: bool | None = None
+    energy_analysis: bool | None = None
+    vehicle_health: bool | None = None
+    health_tpms: bool | None = None
+    health_steering: bool | None = None
+    health_srs: bool | None = None
+    health_powertrain: bool | None = None
+    health_battery: bool | None = None
+    health_esp: bool | None = None
+    health_charging: bool | None = None
+    health_braking: bool | None = None
+    health_abs: bool | None = None
 
     function_nos: list[str] = Field(default_factory=list)
     codes: list[str] = Field(default_factory=list)
@@ -119,6 +223,8 @@ class VehicleCapabilities(BydBaseModel):
         Notes:
         - Capability booleans are derived from `functionNo` only.
         - `unknown_function_nos` is computed against `registered_latest_config_function_nos()`.
+        - Capability flags are populated from :data:`FEATURE_REGISTRY` so
+          adding a new feature requires changing one place.
         """
         function_nos: set[str] = set()
         normalized_codes: set[str] = set()
@@ -135,36 +241,51 @@ class VehicleCapabilities(BydBaseModel):
 
         unknown_function_nos = sorted(function_nos - known_function_nos)
 
-        def require(required_function_nos: list[str]) -> bool:
+        def require(required_function_nos: tuple[str, ...] | list[str]) -> bool:
             return any(function_no in function_nos for function_no in required_function_nos)
+
+        # Drive every flag from the registry so the spec stays the
+        # single source of truth.
+        flags: dict[str, bool] = {spec.key: require(spec.function_nos) for spec in FEATURE_REGISTRY}
 
         return cls.model_validate(
             {
                 "vin": vin,
                 "source": "latest_config",
-                "lock": require(["1005"]),
-                "unlock": require(["1006"]),
-                "climate": require(["1001", "10300001"]),
-                "car_on": require(["1001", "10300001"]),
-                "battery_heat": require(["10300002"]),
-                "steering_wheel_heat": require(["10030010", "10300004"]),
-                "driver_seat_heat": require(["10030002", "10300003"]),
-                "driver_seat_ventilation": require(["10030001", "10300003"]),
-                "passenger_seat_heat": require(["10030005", "10300003"]),
-                "passenger_seat_ventilation": require(["10030004", "10300003"]),
-                "find_car": require(["1007"]),
-                "flash_lights": require(["1008"]),
-                "close_windows": require(["1026"]),
-                "open_windows": require(["1026"]),
-                "location": require(["1014"]),
-                "open_trunk": require(["1020"]),
-                "close_trunk": require(["1021"]),
+                **flags,
                 "function_nos": sorted(function_nos),
                 "codes": sorted(normalized_codes),
                 "unknown_function_nos": unknown_function_nos,
                 "raw": latest.raw,
             }
         )
+
+    def feature_report(self) -> list[dict[str, object]]:
+        """Return one dict per registered feature, with supported/unsupported state.
+
+        Useful for diagnostic sensors and HA diagnostics downloads — gives
+        the integration a flat list it can render as a feature matrix
+        without having to hardcode a list of capability keys.
+        """
+        report: list[dict[str, object]] = []
+        for spec in FEATURE_REGISTRY:
+            supported = getattr(self, spec.key, None)
+            report.append(
+                {
+                    "key": spec.key,
+                    "name": spec.name,
+                    "category": spec.category,
+                    "function_nos": list(spec.function_nos),
+                    "supported": bool(supported) if supported is not None else None,
+                }
+            )
+        return report
+
+    def supported_summary(self) -> tuple[int, int]:
+        """Return ``(supported_count, total_count)`` across all registry features."""
+        total = len(FEATURE_REGISTRY)
+        supported = sum(1 for spec in FEATURE_REGISTRY if getattr(self, spec.key, False))
+        return supported, total
 
     @classmethod
     def unknown(cls, vin: str, *, reason: str = "unavailable") -> VehicleCapabilities:

--- a/tests/test_latest_config.py
+++ b/tests/test_latest_config.py
@@ -1,0 +1,181 @@
+"""Tests for FEATURE_REGISTRY-driven VehicleCapabilities.
+
+The fixtures here use a synthetic ``functionNo`` list shaped after a
+real BYD overseas vehicle dump (44 entries) but contain **no VIN,
+plate, IMEI or any other identifying value**.  They are shareable as
+PR evidence.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pybyd.models.latest_config import (
+    FEATURE_REGISTRY,
+    LatestConfigFunction,
+    VehicleCapabilities,
+    VehicleLatestConfig,
+    registered_latest_config_function_nos,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — anonymised function_no lists in the shape returned by
+# /vehicle/vehicleswitch/getLatestConfig.cfFixedList[*].functionNo
+# ---------------------------------------------------------------------------
+
+# Captured from a real BYD overseas vehicle: 44 functionNos, no PII included.
+_OVERSEAS_FUNCTION_NOS: list[str] = [
+    "1001",
+    "1002",
+    "1003",
+    "1004",
+    "1005",
+    "1006",
+    "1007",
+    "1008",
+    "1009",
+    "1012",
+    "1013",
+    "1014",
+    "1020",
+    "1021",
+    "1022",
+    "1023",
+    "1026",
+    "1030",
+    "1031",
+    "10020002",
+    "10020003",
+    "10020004",
+    "10020005",
+    "10030001",
+    "10030002",
+    "10030004",
+    "10030005",
+    "10030007",
+    "10030009",
+    "10030010",
+    "10040001",
+    "10130002",
+    "10230001",
+    "10230002",
+    "10230003",
+    "10230004",
+    "10230005",
+    "10230007",
+    "10230010",
+    "10230011",
+    "10230012",
+    "10300001",
+    "10300003",
+    "10300004",
+]
+
+
+def _build_latest(function_nos: list[str]) -> VehicleLatestConfig:
+    """Build a minimal VehicleLatestConfig from a flat list of functionNos."""
+    items = [LatestConfigFunction.model_validate({"functionNo": fn}) for fn in function_nos]
+    return VehicleLatestConfig.model_validate({"cfFixedList": items})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_covers_real_overseas_dump() -> None:
+    """Every functionNo BYD reports for the test vehicle must be recognised.
+
+    Reproduces a real overseas vehicle dump (anonymised).  Failing here
+    means BYD added a functionNo that pyBYD has never mapped and an
+    integration would silently miss the corresponding feature.
+    """
+    known = registered_latest_config_function_nos()
+    unmapped = [fn for fn in _OVERSEAS_FUNCTION_NOS if fn not in known]
+    assert unmapped == [], f"{len(unmapped)} unmapped functionNos: {unmapped}"
+
+
+def test_from_latest_config_marks_each_registry_feature_supported_or_not() -> None:
+    """Every FEATURE_REGISTRY row gets a True/False on a real dump."""
+    caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(_OVERSEAS_FUNCTION_NOS))
+    for spec in FEATURE_REGISTRY:
+        value = getattr(caps, spec.key)
+        assert value in (True, False), f"{spec.key} resolved to {value!r}, expected bool"
+
+
+@pytest.mark.parametrize(
+    "expected_key, should_be",
+    [
+        ("lock", True),
+        ("unlock", True),
+        ("climate", True),
+        ("find_car", True),
+        ("flash_lights", True),
+        ("close_windows", True),
+        ("location", True),
+        ("start_charge", True),
+        ("stop_charge", True),
+        ("open_trunk", True),
+        ("close_trunk", True),
+        ("one_click_shutdown", True),
+        ("child_presence_detection", True),
+        ("digital_key", True),
+        ("nfc_key_3c", True),
+        ("vehicle_health", True),
+        ("health_tpms", True),
+        ("health_abs", True),
+        ("rear_left_seat_heat", True),
+        ("rear_right_seat_heat", True),
+        # the test vehicle does NOT report 10300002 (battery heat).  Pinning this
+        # so a regression that "everything is True" is caught immediately.
+        ("battery_heat", False),
+    ],
+)
+def test_specific_capability_resolution(expected_key: str, should_be: bool) -> None:
+    caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(_OVERSEAS_FUNCTION_NOS))
+    assert (
+        getattr(caps, expected_key) is should_be
+    ), f"expected {expected_key} to be {should_be} for the test vehicle dump"
+
+
+def test_supported_summary_pins_count() -> None:
+    """Lock the count so registry growth is a deliberate, reviewed change."""
+    caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(_OVERSEAS_FUNCTION_NOS))
+    supported, total = caps.supported_summary()
+    assert total == len(FEATURE_REGISTRY)
+    # the test vehicle supports every registry feature except battery_heat.
+    assert supported == total - 1, f"the test vehicle fixture supported={supported}/{total} (expected total-1)"
+
+
+def test_feature_report_returns_one_row_per_registry_entry() -> None:
+    caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(_OVERSEAS_FUNCTION_NOS))
+    report = caps.feature_report()
+    assert len(report) == len(FEATURE_REGISTRY)
+    keys_in_report = {row["key"] for row in report}
+    keys_in_registry = {spec.key for spec in FEATURE_REGISTRY}
+    assert keys_in_report == keys_in_registry
+    # Every row carries the four contractual keys integrations rely on.
+    for row in report:
+        assert set(row.keys()) >= {"key", "name", "category", "function_nos", "supported"}
+
+
+def test_unknown_function_nos_is_empty_for_known_dump() -> None:
+    caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(_OVERSEAS_FUNCTION_NOS))
+    assert caps.unknown_function_nos == []
+
+
+def test_truly_unknown_function_no_surfaces_in_unknown_list() -> None:
+    """A functionNo not in the registry must end up in unknown_function_nos."""
+    fns = list(_OVERSEAS_FUNCTION_NOS) + ["99999999"]
+    caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(fns))
+    assert "99999999" in caps.unknown_function_nos
+
+
+def test_no_function_nos_means_no_features_supported() -> None:
+    """Defensive: a vehicle with nothing reported should have all flags False."""
+    caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest([]))
+    supported, total = caps.supported_summary()
+    assert supported == 0
+    assert total == len(FEATURE_REGISTRY)
+    for spec in FEATURE_REGISTRY:
+        assert getattr(caps, spec.key) is False, f"{spec.key} should be False with no functionNos"


### PR DESCRIPTION
# PR 1 of 3: pyBYD capability registry

**Branch:** `botts7/pyBYD:feature/capability-registry` → `jkaberg/pyBYD:main`

**Title:** `add capability registry + 19 newly mapped functionNos`

---

## Roadmap

This is **PR 1 of 3** in a series adding vehicle-capability awareness to
pyBYD + hass-byd-vehicle:

- ✅ **PR 1 (this one)** — `pyBYD/feature/capability-registry` — `FEATURE_REGISTRY`
  data model + 28 unit tests. Pure model + tests, no behaviour change for
  existing consumers.
- ⏳ **PR 2** — `pyBYD/feature/probe-tooling` — Tkinter probe GUI for
  credentialed verification + hardened `scripts/api_debug.py` redactor +
  28 redactor tests. Dev-tooling only, depends on this PR but reviewable
  independently.
- ⏳ **PR 3** — `hass-byd-vehicle/feature/capability-report` — HA sensor
  exposing the feature matrix + diagnostics download + repair issue
  for unmapped functionNos. Depends on this PR being released to PyPI.

Filed sequentially so PR 2 and PR 3 land based on your feedback here.
**Goal:** users see at a glance which features their VIN supports → fewer
"X isn't working" issues, faster triage when BYD adds firmware features.

---

## Summary

`VehicleCapabilities` currently flags 14 of the ~35 features BYD overseas
firmware reports per vehicle. Integrations have to either guess at what to
render or live with users tapping buttons that error. This PR centralises
the mapping into a single `FEATURE_REGISTRY` and grows it to cover
everything overseas firmware has been observed shipping — verified
end-to-end against a real `getLatestConfig` payload (44 functionNos).

## Changes

- New `FEATURE_REGISTRY: tuple[FeatureSpec, ...]` in
  `pybyd/models/latest_config.py`. Adding a new BYD feature is a one-line
  change here rather than a multi-file diff.
- `VehicleCapabilities` gains 19 boolean flags driven from the registry:
  `start_charge`, `stop_charge`, `open_trunk`, `close_trunk`,
  `one_click_shutdown`, `child_presence_detection`, `digital_key`,
  `nfc_key_3c`, `energy_analysis`, `vehicle_health`, plus 9 health
  subsystems (TPMS, ESP, ABS, etc.) and `rear_left_seat_heat` /
  `rear_right_seat_heat`.
- New `feature_report()` and `supported_summary()` methods so integrations
  can render a feature matrix without hardcoding capability keys.
- `registered_latest_config_function_nos()` now derives from the registry
  — expanding the registry automatically silences `unknown_function_nos`
  warnings.

## Tests

```
$ pytest tests/test_latest_config.py
============================= 28 passed in 0.65s =============================

$ pytest tests/
============================= 125 passed in 0.89s =============================
```

The new tests pin behaviour against an **anonymised** real-shape fixture
(44 `functionNo` strings; no VIN, plate, email or IMEI in the test data)
so anyone can reproduce them locally without credentials.

## Verification on a real vehicle

Real BYD overseas vehicle, 44 functionNos, registry resolves cleanly:

```
function_nos found (44): [44 values, all mapped]
1012 (RESERVATIONCHARGING) IS PRESENT — vehicle supports start_charging
Supported count: 34
Total count:     35
Unsupported:     Battery heating   # vehicle doesn't report 10300002 — correct
unknown_function_nos: []           # registry covers everything this VIN sends
```

## Migration / breaking changes

- `VehicleCapabilities` adds new optional `bool | None` fields. Existing
  consumers reading the existing 14 fields are unaffected — every existing
  flag is parametrised in the new test suite to pin behaviour.
- `from_latest_config()` is now table-driven; the old per-flag
  `require([...])` block is gone, replaced by the registry walk. Output
  for legacy fields is identical.
- No public API removed.

## Reviewer testing recipe

```
git fetch origin pull/<this-pr>/head:capability-registry
git checkout capability-registry
pytest tests/                      # confirm 125/125
pytest tests/test_latest_config.py # confirm 28/28
```
