### PR TITLE
Smart-charging schedule with trigger+poll save flow

### DIFF
--- a/src/pybyd/_api/charging.py
+++ b/src/pybyd/_api/charging.py
@@ -1,12 +1,31 @@
 """Smart charging status endpoint.
 
 Endpoint:
-  - /control/smartCharge/homePage
+  - /control/smartCharge/homePage  (live state + configured schedule, one call)
+
+The endpoint returns both the live charging state (SOC, charge state,
+time-to-full) and the user's configured schedule (start/end times,
+``chargeWay``, etc.) in a single response.  We parse the same payload
+into two specialised models so each can evolve independently:
+
+* :class:`ChargingStatus` — live fields, also pushed via MQTT.
+* :class:`SmartChargingSchedule` — schedule config, HTTP-only.
+
+Callers that only care about one view should use
+:func:`fetch_charging_status` or :func:`pybyd._api.smart_charging.fetch_charging_schedule`.
+:func:`fetch_charging_homepage` returns the raw dict for callers that
+want to populate both with a single request.
 """
 
 from __future__ import annotations
 
-from pybyd._api._common import ENDPOINT_NOT_SUPPORTED_CODES, build_inner_base, post_token_json
+from typing import Any
+
+from pybyd._api._common import (
+    ENDPOINT_NOT_SUPPORTED_CODES,
+    build_inner_base,
+    post_token_json,
+)
 from pybyd._transport import Transport
 from pybyd.config import BydConfig
 from pybyd.models.charging import ChargingStatus
@@ -15,13 +34,20 @@ from pybyd.session import Session
 _ENDPOINT = "/control/smartCharge/homePage"
 
 
-async def fetch_charging_status(
+async def fetch_charging_homepage(
     config: BydConfig,
     session: Session,
     transport: Transport,
     vin: str,
-) -> ChargingStatus:
-    """Fetch smart charging status (SOC, charge state, time-to-full)."""
+) -> dict[str, Any]:
+    """POST ``/control/smartCharge/homePage`` and return the raw response dict.
+
+    Both :func:`fetch_charging_status` and
+    :func:`pybyd._api.smart_charging.fetch_charging_schedule` build on
+    this — and :meth:`pybyd.client.BydClient.get_charging_homepage`
+    parses one raw response into both views, so a "force refresh" only
+    spends one round-trip to update live state *and* schedule together.
+    """
     inner = build_inner_base(config, vin=vin)
     decoded = await post_token_json(
         endpoint=_ENDPOINT,
@@ -32,4 +58,15 @@ async def fetch_charging_status(
         vin=vin,
         not_supported_codes=ENDPOINT_NOT_SUPPORTED_CODES,
     )
-    return ChargingStatus.model_validate(decoded)
+    return decoded if isinstance(decoded, dict) else {}
+
+
+async def fetch_charging_status(
+    config: BydConfig,
+    session: Session,
+    transport: Transport,
+    vin: str,
+) -> ChargingStatus:
+    """Fetch smart charging status (SOC, charge state, time-to-full)."""
+    raw = await fetch_charging_homepage(config, session, transport, vin)
+    return ChargingStatus.model_validate(raw)

--- a/src/pybyd/_api/energy.py
+++ b/src/pybyd/_api/energy.py
@@ -6,10 +6,13 @@ Endpoint:
 
 from __future__ import annotations
 
+from typing import Any
+
 from pybyd._api._common import ENDPOINT_NOT_SUPPORTED_CODES, build_inner_base, post_token_json
 from pybyd._transport import Transport
 from pybyd.config import BydConfig
 from pybyd.models.energy import EnergyConsumption
+from pybyd.models.vehicle import EnergyType
 from pybyd.session import Session
 
 _ENDPOINT = "/vehicleInfo/vehicle/getEnergyConsumption"
@@ -20,8 +23,20 @@ async def fetch_energy_consumption(
     session: Session,
     transport: Transport,
     vin: str,
+    *,
+    power_type: EnergyType = EnergyType.EV,
+    auto_model_name: str | None = None,
 ) -> EnergyConsumption:
     """Fetch energy consumption data for a vehicle.
+
+    The BYD app sends three request fields beyond ``build_inner_base``:
+
+    - ``powerType``: ``EnergyType`` — sent on the wire as ``"0"`` (EV view),
+      ``"1"`` (ICE view), or ``"2"`` (hybrid combined). Hybrids only populate
+      both legs at ``HYBRID``.
+    - ``requestType``: ``0`` (int) — purpose unknown but the BYD app sends it.
+    - ``autoModelNameOut``: vehicle's marketing model name (e.g. ``"BYD SHARK"``).
+      Without it the ``autoModelGraph`` section zero-fills.
 
     Parameters
     ----------
@@ -33,6 +48,13 @@ async def fetch_energy_consumption(
         HTTP transport.
     vin : str
         Vehicle Identification Number.
+    power_type : EnergyType
+        Defaults to ``EnergyType.EV`` to preserve the old hard-coded
+        behaviour for any direct caller. ``BydClient.get_energy_consumption``
+        supplies the per-vehicle ``energy_type`` value.
+    auto_model_name : str | None
+        Vehicle marketing name for the ``autoModelGraph`` lookup. Optional
+        — if absent, ``autoModelGraph`` returns zeros.
 
     Returns
     -------
@@ -44,7 +66,11 @@ async def fetch_energy_consumption(
     BydApiError
         If the API returns an error.
     """
-    inner = build_inner_base(config, vin=vin)
+    inner: dict[str, Any] = dict(build_inner_base(config, vin=vin))
+    inner["powerType"] = str(int(power_type))
+    inner["requestType"] = 0
+    if auto_model_name:
+        inner["autoModelNameOut"] = auto_model_name
     decoded = await post_token_json(
         endpoint=_ENDPOINT,
         config=config,

--- a/src/pybyd/_api/realtime.py
+++ b/src/pybyd/_api/realtime.py
@@ -13,6 +13,7 @@ from typing import Any
 from pybyd._api._common import ENDPOINT_NOT_SUPPORTED_CODES, build_inner_base, post_token_json
 from pybyd._transport import Transport
 from pybyd.config import BydConfig
+from pybyd.models.vehicle import EnergyType
 from pybyd.session import Session
 
 
@@ -23,11 +24,19 @@ async def fetch_realtime_endpoint(
     transport: Transport,
     vin: str,
     request_serial: str | None = None,
+    *,
+    energy_type: EnergyType = EnergyType.EV,
 ) -> tuple[dict[str, Any], str | None]:
-    """Fetch a single realtime endpoint, returning (vehicle_info_dict, next_serial)."""
+    """Fetch a single realtime endpoint, returning (vehicle_info_dict, next_serial).
+
+    ``energy_type`` mirrors the per-vehicle ``energyType`` returned by the
+    vehicle-list endpoint. Hybrid vehicles (``EnergyType.HYBRID``) return
+    combined EV+ICE range/consumption fields; sending ``EnergyType.EV`` for
+    a hybrid causes the cloud to zero-out the ICE-side fields.
+    """
     now_ms = int(time.time() * 1000)
     inner = build_inner_base(config, now_ms=now_ms, vin=vin, request_serial=request_serial)
-    inner["energyType"] = "0"
+    inner["energyType"] = str(int(energy_type))
     inner["tboxVersion"] = config.tbox_version
 
     decoded = await post_token_json(

--- a/src/pybyd/_api/smart_charging.py
+++ b/src/pybyd/_api/smart_charging.py
@@ -1,6 +1,7 @@
 """Smart charging control endpoints.
 
 Endpoints:
+  - /control/smartCharge/homePage            (read schedule + live SoC)
   - /control/smartCharge/changeChargeStatue  (toggle on/off, or start/stop charge)
   - /control/smartCharge/changeResult        (poll until status change settles)
   - /control/smartCharge/saveOrUpdate        (save schedule)
@@ -12,17 +13,52 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from pybyd._api._common import ENDPOINT_NOT_SUPPORTED_CODES, build_inner_base, post_token_json
+from pybyd._api._common import (
+    ENDPOINT_NOT_SUPPORTED_CODES,
+    build_inner_base,
+    post_token_json,
+)
+from pybyd._api.charging import fetch_charging_homepage
 from pybyd._transport import Transport
 from pybyd.config import BydConfig
+from pybyd.exceptions import BydDataUnavailableError
 from pybyd.models.control import CommandAck
+from pybyd.models.smart_charging import SmartChargingSchedule
 from pybyd.session import Session
 
 _TOGGLE_ENDPOINT = "/control/smartCharge/changeChargeStatue"
 _RESULT_ENDPOINT = "/control/smartCharge/changeResult"
 _SAVE_ENDPOINT = "/control/smartCharge/saveOrUpdate"
 
+#: Cloud error codes meaning the cloud accepted the request but couldn't
+#: reach the vehicle right now (weak cellular signal, vehicle parked
+#: somewhere with no coverage, etc.).  Recoverable — the user should
+#: retry once the vehicle is back online.
+VEHICLE_UNREACHABLE_CODES: frozenset[str] = frozenset({"6002"})
+
 _logger = logging.getLogger(__name__)
+
+
+async def fetch_charging_schedule(
+    config: BydConfig,
+    session: Session,
+    transport: Transport,
+    vin: str,
+) -> SmartChargingSchedule:
+    """Fetch the configured smart-charging schedule.
+
+    Hits the same ``/control/smartCharge/homePage`` endpoint as
+    :func:`pybyd._api.charging.fetch_charging_status` but parses the
+    nested ``smartChargeDto`` / ``smartJourneyDto`` blocks (the schedule
+    config) rather than the top-level live charging fields.
+
+    Two parsers split off the same response so the live state (which
+    MQTT also pushes as :class:`ChargingStatus`) and the schedule config
+    (HTTP-only, on-demand) can be cached on different snapshot sections
+    without one clobbering the other.
+    """
+    raw = await fetch_charging_homepage(config, session, transport, vin)
+    return SmartChargingSchedule.model_validate({"vin": vin, **raw})
 
 
 async def toggle_smart_charging(
@@ -153,6 +189,45 @@ def make_change_charge_fetch_fn(*, start: bool) -> Callable[..., Awaitable[tuple
     return _fetch
 
 
+def make_save_charging_schedule_fetch_fn(
+    *,
+    start_charge_time: str,
+    end_charge_time: str,
+    charge_way: str,
+    enabled: bool,
+) -> Callable[..., Awaitable[tuple[dict[str, Any], str | None]]]:
+    """Adapter for :meth:`BydClient._trigger_and_poll` for ``saveOrUpdate``.
+
+    Dispatches the trigger leg to :func:`trigger_save_charging_schedule`
+    and the poll leg to :func:`poll_charge_result` — the same pattern
+    used for ``changeChargeStatue`` start/stop, since ``saveOrUpdate``
+    follow-ups also resolve via ``changeResult``.
+    """
+
+    async def _fetch(
+        endpoint: str,
+        config: BydConfig,
+        session: Session,
+        transport: Transport,
+        vin: str,
+        request_serial: str | None = None,
+    ) -> tuple[dict[str, Any], str | None]:
+        if endpoint == _RESULT_ENDPOINT:
+            return await poll_charge_result(config, session, transport, vin, request_serial or "")
+        return await trigger_save_charging_schedule(
+            config,
+            session,
+            transport,
+            vin,
+            start_charge_time=start_charge_time,
+            end_charge_time=end_charge_time,
+            charge_way=charge_way,
+            enabled=enabled,
+        )
+
+    return _fetch
+
+
 def is_charge_change_ready(payload: dict[str, Any]) -> bool:
     """Predicate for :meth:`BydClient._trigger_and_poll`'s ``is_ready``.
 
@@ -165,46 +240,52 @@ def is_charge_change_ready(payload: dict[str, Any]) -> bool:
     return isinstance(res, int) and res != 1
 
 
-async def save_charging_schedule(
+async def trigger_save_charging_schedule(
     config: BydConfig,
     session: Session,
     transport: Transport,
     vin: str,
     *,
-    target_soc: int,
-    start_hour: int,
-    start_minute: int,
-    end_hour: int,
-    end_minute: int,
-) -> CommandAck:
-    """Save a smart charging schedule.
+    start_charge_time: str,
+    end_charge_time: str,
+    charge_way: str,
+    enabled: bool = True,
+) -> tuple[dict[str, Any], str | None]:
+    """POST ``/control/smartCharge/saveOrUpdate`` to push a new schedule.
+
+    Wire format mirrors the BYD-app capture under
+    ``captures/logs_decrypted/timetable_set_*/01_control_smartCharge_saveOrUpdate.json``:
+    ``startChargeTime`` / ``endChargeTime`` are ``"HH:MM"`` strings (or
+    the sentinel ``"full"`` on ``endChargeTime``), ``chargeWay`` is the
+    repeat selector, and ``status`` is the enabled flag.
+
+    Returns ``(raw_response, request_serial)``.  The ``requestSerial``
+    is then used to poll ``changeResult`` until the cloud confirms the
+    schedule was applied (``res == 2``) or returns a terminal failure
+    — the same lifecycle as ``changeChargeStatue`` start/stop.
 
     Parameters
     ----------
-    target_soc : int
-        Target state of charge (0-100).
-    start_hour : int
-        Scheduled start hour (0-23).
-    start_minute : int
-        Scheduled start minute (0-59).
-    end_hour : int
-        Scheduled end hour (0-23).
-    end_minute : int
-        Scheduled end minute (0-59).
-
-    Returns
-    -------
-    CommandAck
-        Decoded API acknowledgement.
+    start_charge_time : str
+        Schedule start as ``"HH:MM"``.
+    end_charge_time : str
+        Schedule end as ``"HH:MM"`` or the literal ``"full"`` sentinel
+        (charge until full within the window).
+    charge_way : str
+        Repeat selector: ``"s"`` (single one-shot), ``"e"`` (every day),
+        or comma-separated weekday indices like ``"0,1,2,3,4"``
+        (``0`` = Monday).
+    enabled : bool
+        Whether the schedule is active.  Defaults to ``True``.
     """
     inner = build_inner_base(config, vin=vin)
     inner.update(
         {
-            "endHour": str(end_hour),
-            "endMinute": str(end_minute),
-            "startHour": str(start_hour),
-            "startMinute": str(start_minute),
-            "targetSoc": str(target_soc),
+            "startChargeTime": start_charge_time,
+            "endChargeTime": end_charge_time,
+            "chargeWay": charge_way,
+            "status": "1" if enabled else "0",
+            "timeZone": "",
         }
     )
     decoded = await post_token_json(
@@ -215,6 +296,7 @@ async def save_charging_schedule(
         inner=inner,
         vin=vin,
         not_supported_codes=ENDPOINT_NOT_SUPPORTED_CODES,
+        extra_code_map={VEHICLE_UNREACHABLE_CODES: BydDataUnavailableError},
     )
     raw = decoded if isinstance(decoded, dict) else {}
-    return CommandAck.model_validate({"vin": vin, **raw, "raw": raw})
+    return raw, raw.get("requestSerial")

--- a/src/pybyd/_state_engine.py
+++ b/src/pybyd/_state_engine.py
@@ -31,6 +31,7 @@ from pybyd.models.energy import EnergyConsumption
 from pybyd.models.gps import GpsInfo
 from pybyd.models.hvac import HvacStatus
 from pybyd.models.realtime import VehicleRealtimeData
+from pybyd.models.smart_charging import SmartChargingSchedule
 from pybyd.models.vehicle import Vehicle
 
 _logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class VehicleSnapshot:
     gps: GpsInfo | None = None
     charging: ChargingStatus | None = None
     energy: EnergyConsumption | None = None
+    charging_schedule: SmartChargingSchedule | None = None
 
 
 # ------------------------------------------------------------------
@@ -75,7 +77,8 @@ class ProjectionSpec:
     """
 
     section: str
-    """State section: ``"realtime"``, ``"hvac"``, ``"gps"``, ``"charging"``, ``"energy"``."""
+    """State section: ``"realtime"``, ``"hvac"``, ``"gps"``, ``"charging"``,
+    ``"energy"``, ``"charging_schedule"``."""
 
     field_name: str
     """Field name within the section model (e.g. ``"left_front_door_lock"``)."""
@@ -141,6 +144,7 @@ class VehicleStateEngine:
         self._base_gps: GpsInfo | None = None
         self._base_charging: ChargingStatus | None = None
         self._base_energy: EnergyConsumption | None = None
+        self._base_charging_schedule: SmartChargingSchedule | None = None
 
         # Active projections
         self._projections: list[FieldProjection] = []
@@ -253,6 +257,13 @@ class VehicleStateEngine:
             self._reconcile_projections("energy", data)
             self._rebuild_snapshot()
 
+    async def update_charging_schedule(self, data: SmartChargingSchedule) -> None:
+        """Merge incoming smart-charging schedule data."""
+        async with self._lock:
+            self._base_charging_schedule = data
+            self._reconcile_projections("charging_schedule", data)
+            self._rebuild_snapshot()
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -357,6 +368,16 @@ class VehicleStateEngine:
             return base
         return base.model_copy(update=updates)
 
+    def _project_charging_schedule(self) -> SmartChargingSchedule | None:
+        """Build projected charging-schedule data (base + projection overlay)."""
+        base = self._base_charging_schedule
+        if base is None:
+            return None
+        updates = self._get_projection_updates("charging_schedule")
+        if not updates:
+            return base
+        return base.model_copy(update=updates)
+
     def _rebuild_snapshot(self) -> None:
         """Rebuild projected snapshot from base state + active projections."""
         # Clean expired projections
@@ -369,6 +390,7 @@ class VehicleStateEngine:
             gps=self._project_gps(),
             charging=self._project_charging(),
             energy=self._project_energy(),
+            charging_schedule=self._project_charging_schedule(),
         )
         self._snapshot = new_snapshot
 

--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -210,10 +210,19 @@ class BydCar:
         return data
 
     async def update_charging(self) -> ChargingStatus:
-        """Fetch fresh charging data and merge into state engine."""
-        data = await self._client.get_charging_status(self._vin)
-        await self._engine.update_charging(data)
-        return data
+        """Fetch fresh charging data + schedule and merge both into state engine.
+
+        The cloud returns both views from one ``homePage`` call, so a
+        force-refresh updates every charging-related field — live state
+        AND the configured schedule — in a single round-trip.  MQTT
+        pushes (which only carry live state) continue to flow through
+        :meth:`handle_mqtt_charging` and never touch the schedule
+        section, so a partial-state push can't clobber the schedule.
+        """
+        status, schedule = await self._client.get_charging_homepage(self._vin)
+        await self._engine.update_charging(status)
+        await self._engine.update_charging_schedule(schedule)
+        return status
 
     async def start_charging(self) -> ChargeChangeResult:
         """Start charging immediately and wait for the toggle to settle.
@@ -232,6 +241,34 @@ class BydCar:
         data = await self._client.get_energy_consumption(self._vin)
         await self._engine.update_energy(data)
         return data
+
+    async def save_charging_schedule(
+        self,
+        *,
+        start_charge_time: str,
+        end_charge_time: str,
+        charge_way: str,
+        enabled: bool = True,
+    ) -> ChargeChangeResult:
+        """Push a new smart-charging schedule and refresh the snapshot.
+
+        Routes through :meth:`BydClient.save_charging_schedule` which
+        triggers ``saveOrUpdate`` and waits for ``changeResult`` to
+        report a terminal state (``res == 2`` success, anything else
+        raises).  Once the cloud has confirmed the new schedule,
+        refreshes the snapshot via :meth:`update_charging` so both
+        the live charging section and the schedule section reflect
+        the post-save state.
+        """
+        result = await self._client.save_charging_schedule(
+            self._vin,
+            start_charge_time=start_charge_time,
+            end_charge_time=end_charge_time,
+            charge_way=charge_way,
+            enabled=enabled,
+        )
+        await self.update_charging()
+        return result
 
     # ------------------------------------------------------------------
     # MQTT integration

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
 import time
 from collections.abc import Awaitable, Callable, Mapping
@@ -63,7 +64,7 @@ from pybyd.models.latest_config import VehicleCapabilities, VehicleLatestConfig
 from pybyd.models.push_notification import PushNotificationState
 from pybyd.models.realtime import VehicleRealtimeData
 from pybyd.models.smart_charging import SmartChargingSchedule
-from pybyd.models.vehicle import Vehicle
+from pybyd.models.vehicle import EnergyType, Vehicle
 from pybyd.session import Session
 
 if TYPE_CHECKING:
@@ -155,6 +156,10 @@ class BydClient:
         self._cars: dict[str, BydCar] = {}
         # Per-VIN normalized capability availability.
         self._vehicle_capabilities: dict[str, VehicleCapabilities] = {}
+        # Per-VIN Vehicle metadata cache. Populated as a side effect of
+        # get_vehicles(). Used to resolve per-vehicle attributes like
+        # energyType without an extra round trip on every realtime call.
+        self._vehicle_metadata_by_vin: dict[str, Vehicle] = {}
         # Whether remote commands are enabled (set by verify_command_access).
         self._commands_enabled: bool = False
 
@@ -520,8 +525,17 @@ class BydClient:
         # --- 2) vehicleInfo callback for on_vehicle_info + BydCar routing ---
         if event.event == "vehicleInfo" and event.vin:
             realtime_parsed: VehicleRealtimeData | None = None
+            cached_vehicle = self._vehicle_metadata_by_vin.get(event.vin)
+            energy_type = (
+                cached_vehicle.energy_type
+                if cached_vehicle is not None and cached_vehicle.energy_type is not EnergyType.UNKNOWN
+                else EnergyType.EV
+            )
             try:
-                realtime_parsed = VehicleRealtimeData.model_validate(respond_data)
+                realtime_parsed = VehicleRealtimeData.model_validate(
+                    respond_data,
+                    context={"energy_type": energy_type},
+                )
             except Exception:
                 _logger.debug("Failed to parse MQTT vehicleInfo", exc_info=True)
 
@@ -750,6 +764,7 @@ class BydClient:
         poll_attempts: int = 10,
         poll_interval: float = 1.5,
         signal_retries: int = 2,
+        validate_context: dict[str, Any] | None = None,
     ) -> _M:
         """Generic trigger → MQTT wait → HTTP poll fallback.
 
@@ -782,10 +797,10 @@ class BydClient:
         merged_latest = trigger_info if isinstance(trigger_info, dict) else {}
 
         if isinstance(trigger_info, dict) and is_ready(trigger_info):
-            return model_cls.model_validate(merged_latest)
+            return model_cls.model_validate(merged_latest, context=validate_context)
 
         if not serial:
-            return model_cls.model_validate(merged_latest)
+            return model_cls.model_validate(merged_latest, context=validate_context)
 
         # Register the serial so _on_mqtt_event can distinguish data-poll
         # responses from genuine remote-control command acks.
@@ -801,7 +816,7 @@ class BydClient:
             )
             if isinstance(mqtt_raw, dict) and is_ready(mqtt_raw):
                 _logger.debug("%s data received via MQTT for vin=%s", label, vin)
-                return model_cls.model_validate(mqtt_raw)
+                return model_cls.model_validate(mqtt_raw, context=validate_context)
 
             # Check if MQTT delivered a definitive "data unavailable" error
             # (e.g. code 6051 = no GPS signal).  Skip HTTP polling entirely.
@@ -815,7 +830,7 @@ class BydClient:
                         mqtt_code,
                         vin,
                     )
-                    return model_cls.model_validate(merged_latest)
+                    return model_cls.model_validate(merged_latest, context=validate_context)
 
             # Phase 3: HTTP poll fallback
             _logger.debug("MQTT timeout; falling back to HTTP polling for %s vin=%s", label, vin)
@@ -861,13 +876,32 @@ class BydClient:
                     consecutive_unavailable = 0  # reset — different error type
                     _logger.debug("%s poll attempt=%d failed", label, attempt, exc_info=True)
 
-            return model_cls.model_validate(merged_latest)
+            return model_cls.model_validate(merged_latest, context=validate_context)
         finally:
             self._data_poll_serials.discard(trigger_serial)
 
     async def get_vehicles(self) -> list[Vehicle]:
         """Fetch all vehicles associated with the account."""
-        return await self._authed_call(_vehicle_api.fetch_vehicle_list)
+        vehicles = await self._authed_call(_vehicle_api.fetch_vehicle_list)
+        self._vehicle_metadata_by_vin = {v.vin: v for v in vehicles if v.vin}
+        return vehicles
+
+    async def _energy_type_for(self, vin: str) -> EnergyType:
+        """Return the per-vehicle :class:`EnergyType`.
+
+        Reads from the vehicle-metadata cache populated by
+        :meth:`get_vehicles`. On a first-time miss the cache is filled
+        via a single vehicle-list fetch. Falls back to
+        :attr:`EnergyType.EV` (the previous hard-coded value) if the VIN
+        cannot be resolved.
+        """
+        cached = self._vehicle_metadata_by_vin.get(vin)
+        if cached is None:
+            await self.get_vehicles()
+            cached = self._vehicle_metadata_by_vin.get(vin)
+        if cached is not None and cached.energy_type is not EnergyType.UNKNOWN:
+            return cached.energy_type
+        return EnergyType.EV
 
     async def get_car(
         self,
@@ -986,12 +1020,18 @@ class BydClient:
         ``vehicleRealTimeResult`` only if MQTT doesn't deliver in time.
         """
 
+        energy_type = await self._energy_type_for(vin)
+        fetch_fn = functools.partial(
+            _realtime_api.fetch_realtime_endpoint,
+            energy_type=energy_type,
+        )
+
         async def _call() -> VehicleRealtimeData:
             return await self._trigger_and_poll(
                 vin=vin,
                 trigger_endpoint="/vehicleInfo/vehicle/vehicleRealTimeRequest",
                 poll_endpoint="/vehicleInfo/vehicle/vehicleRealTimeResult",
-                fetch_fn=_realtime_api.fetch_realtime_endpoint,
+                fetch_fn=fetch_fn,
                 is_ready=VehicleRealtimeData.is_ready_raw,
                 model_cls=VehicleRealtimeData,
                 label="Realtime",
@@ -1000,6 +1040,7 @@ class BydClient:
                 poll_attempts=poll_attempts,
                 poll_interval=poll_interval,
                 signal_retries=signal_retries,
+                validate_context={"energy_type": energy_type},
             )
 
         return await self._call_with_reauth(_call)
@@ -1046,8 +1087,22 @@ class BydClient:
         return await self._authed_call(_charging_api.fetch_charging_status, vin)
 
     async def get_energy_consumption(self, vin: str) -> EnergyConsumption:
-        """Fetch energy consumption data."""
-        return await self._authed_call(_energy_api.fetch_energy_consumption, vin)
+        """Fetch energy consumption data.
+
+        Sends ``powerType=<vehicle.energy_type>`` and the vehicle's
+        ``outModelType`` (or ``modelName``) as ``autoModelNameOut`` so
+        the cloud returns the per-leg breakdown for hybrids and the
+        ``autoModelGraph`` model-average comparison.
+        """
+        power_type = await self._energy_type_for(vin)
+        cached = self._vehicle_metadata_by_vin.get(vin)
+        auto_model_name = ((cached.out_model_type or cached.model_name) if cached is not None else None) or None
+        return await self._authed_call(
+            _energy_api.fetch_energy_consumption,
+            vin,
+            power_type=power_type,
+            auto_model_name=auto_model_name,
+        )
 
     async def get_push_state(self, vin: str) -> PushNotificationState:
         """Fetch push notification state."""

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1086,6 +1086,35 @@ class BydClient:
         """Fetch charging status."""
         return await self._authed_call(_charging_api.fetch_charging_status, vin)
 
+    async def get_charging_schedule(self, vin: str) -> SmartChargingSchedule:
+        """Fetch the configured smart-charging schedule.
+
+        Reads ``/control/smartCharge/homePage`` and parses the nested
+        ``smartChargeDto`` / ``smartJourneyDto`` blocks into a
+        :class:`SmartChargingSchedule`.
+        """
+        return await self._authed_call(_smart_api.fetch_charging_schedule, vin)
+
+    async def get_charging_homepage(
+        self,
+        vin: str,
+    ) -> tuple[ChargingStatus, SmartChargingSchedule]:
+        """Fetch live charging state + schedule from one homePage call.
+
+        The cloud returns both views in a single payload, so callers
+        that want a "force refresh" of every charging-related field
+        (e.g. after editing the schedule, or on integration startup)
+        can spend a single HTTP round-trip instead of two.
+
+        :class:`ChargingStatus` continues to also arrive via MQTT pushes
+        — this combined call exists alongside, not in place of, the
+        push path.
+        """
+        raw = await self._authed_call(_charging_api.fetch_charging_homepage, vin)
+        status = ChargingStatus.model_validate(raw)
+        schedule = SmartChargingSchedule.model_validate({"vin": vin, **raw})
+        return status, schedule
+
     async def get_energy_consumption(self, vin: str) -> EnergyConsumption:
         """Fetch energy consumption data.
 
@@ -1341,36 +1370,75 @@ class BydClient:
     async def save_charging_schedule(
         self,
         vin: str,
-        schedule: SmartChargingSchedule,
-    ) -> CommandAck:
-        """Save a smart charging schedule."""
-        if (
-            schedule.target_soc is None
-            or schedule.start_hour is None
-            or schedule.start_minute is None
-            or schedule.end_hour is None
-            or schedule.end_minute is None
-        ):
-            raise ValueError("SmartChargingSchedule must have all time fields set")
-        target_soc = schedule.target_soc
-        start_hour = schedule.start_hour
-        start_minute = schedule.start_minute
-        end_hour = schedule.end_hour
-        end_minute = schedule.end_minute
+        *,
+        start_charge_time: str,
+        end_charge_time: str,
+        charge_way: str,
+        enabled: bool = True,
+        mqtt_timeout: float | None = None,
+        poll_attempts: int = 6,
+        poll_interval: float = 2.0,
+    ) -> ChargeChangeResult:
+        """Save a smart-charging schedule and wait for the toggle to settle.
 
-        async def _call() -> CommandAck:
-            session = await self.ensure_session()
-            transport = self._require_transport()
-            return await _smart_api.save_charging_schedule(
-                self._config,
-                session,
-                transport,
-                vin,
-                target_soc=target_soc,
-                start_hour=start_hour,
-                start_minute=start_minute,
-                end_hour=end_hour,
-                end_minute=end_minute,
+        Wire format mirrors the BYD-app ``saveOrUpdate`` capture.  Times
+        are ``"HH:MM"`` strings; ``end_charge_time`` may also be the
+        sentinel ``"full"`` (charge until full within the window).
+        ``charge_way`` selects the repeat: ``"s"`` single, ``"e"`` every
+        day, or comma-separated weekday indices like ``"0,1,2,3,4"``
+        (``0`` = Monday).
+
+        Gates on ``functionNo "1012"`` (BYD's ``RESERVATIONCHARGING``
+        capability flag — the same gate ``start_charging`` uses, since
+        cars without it can't accept any ``/control/smartCharge/*``
+        call).  Routes through :meth:`_trigger_and_poll`: triggers
+        ``saveOrUpdate``, then prefers an MQTT ``smartCharge`` push for
+        the result and falls back to ``changeResult`` HTTP polling.
+        Returns the terminal :class:`ChargeChangeResult` (``res == 2``)
+        or raises :class:`BydRemoteControlError` for terminal failure /
+        timeout.
+        """
+        capabilities = await self.get_vehicle_capabilities(vin)
+        gate = evaluate_command_gate(RemoteCommand.START_CHARGE, capabilities)
+        if not gate.supported:
+            raise BydEndpointNotSupportedError(
+                (f"save_charging_schedule blocked for VIN {vin}: " f"gate={gate.gate_id} reason={gate.reason}"),
+                code="command_gate_blocked",
+                endpoint="/control/smartCharge/saveOrUpdate",
+            )
+
+        async def _call() -> ChargeChangeResult:
+            result = await self._trigger_and_poll(
+                vin=vin,
+                trigger_endpoint="/control/smartCharge/saveOrUpdate",
+                poll_endpoint="/control/smartCharge/changeResult",
+                fetch_fn=_smart_api.make_save_charging_schedule_fetch_fn(
+                    start_charge_time=start_charge_time,
+                    end_charge_time=end_charge_time,
+                    charge_way=charge_way,
+                    enabled=enabled,
+                ),
+                is_ready=_smart_api.is_charge_change_ready,
+                model_cls=ChargeChangeResult,
+                label="SaveChargingSchedule",
+                mqtt_event_type="smartCharge",
+                mqtt_timeout=mqtt_timeout,
+                poll_attempts=poll_attempts,
+                poll_interval=poll_interval,
+            )
+            res = result.res
+            if res == 2:
+                return result
+            if res is None:
+                raise BydRemoteControlError(
+                    ("smartCharge saveOrUpdate timed out without a terminal " "result"),
+                    code="timeout",
+                    endpoint="/control/smartCharge/changeResult",
+                )
+            raise BydRemoteControlError(
+                (f"smartCharge saveOrUpdate rejected by cloud (res={res}, " f"message={result.message!r})"),
+                code=str(res),
+                endpoint="/control/smartCharge/changeResult",
             )
 
         return await self._call_with_reauth(_call)

--- a/src/pybyd/models/__init__.py
+++ b/src/pybyd/models/__init__.py
@@ -41,7 +41,7 @@ from pybyd.models.realtime import (
 )
 from pybyd.models.smart_charging import SmartChargingSchedule
 from pybyd.models.token import AuthToken
-from pybyd.models.vehicle import EmpowerRange, Vehicle
+from pybyd.models.vehicle import EmpowerRange, EnergyType, Vehicle
 
 __all__ = [
     "AirCirculationMode",
@@ -66,6 +66,7 @@ __all__ = [
     "DoorOpenState",
     "EmpowerRange",
     "EnergyConsumption",
+    "EnergyType",
     "GpsInfo",
     "HvacStatus",
     "LatestConfigFunction",

--- a/src/pybyd/models/_base.py
+++ b/src/pybyd/models/_base.py
@@ -56,15 +56,37 @@ _MS_THRESHOLD = 1_000_000_000_000
 
 
 def parse_byd_timestamp(value: Any) -> datetime | None:
-    """Convert a BYD epoch timestamp (seconds **or** milliseconds) to a UTC datetime.
+    """Convert a BYD timestamp to a UTC datetime.
 
-    Returns ``None`` when the value is ``None`` or not numeric.
+    Accepts:
+
+    * ``int`` / numeric string — epoch seconds *or* milliseconds (auto-detected)
+    * ISO-8601 string — e.g. ``"2026-05-07T05:56:45.000+00:00"`` from the
+      ``smartChargeDto`` schedule blocks
+
+    Returns ``None`` when the value is ``None`` or unparseable.
     """
     if value is None:
         return value
     if isinstance(value, datetime):
         return value
-    ts = int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if not text.lstrip("-").isdigit():
+            try:
+                # ``Z`` suffix isn't accepted by fromisoformat until 3.11.
+                normalised = text.replace("Z", "+00:00")
+                dt = datetime.fromisoformat(normalised)
+            except ValueError:
+                return None
+            return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+        value = text
+    try:
+        ts = int(value)
+    except (TypeError, ValueError):
+        return None
     if ts >= _MS_THRESHOLD:
         ts = ts // 1000
     return datetime.fromtimestamp(ts, tz=UTC)

--- a/src/pybyd/models/energy.py
+++ b/src/pybyd/models/energy.py
@@ -1,15 +1,145 @@
-"""Energy consumption data model."""
+"""Energy consumption data model.
+
+The ``getEnergyConsumption`` endpoint returns a four-section nested
+object: two 7-day rolling graphs (``selfGraph``, ``autoModelGraph``)
+plus per-leg breakouts for lifetime totals (``cumulativeEnergyConsumption``)
+and the last 50km (``nearestEnergyConsumption``). For hybrids
+each leg is exposed in its own field — no string splitting required.
+"""
 
 from __future__ import annotations
 
-from pybyd.models._base import BydBaseModel
+from typing import Annotated, Any, ClassVar
+
+from pydantic import BeforeValidator, Field
+
+from pybyd.models._base import BydBaseModel, BydTimestamp
+
+
+def _to_float(value: Any) -> float | None:
+    """Coerce BYD numeric strings to ``float``; sentinels → ``None``."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if text in ("", "--", "nan", "NaN"):
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _to_int(value: Any) -> int | None:
+    """Coerce BYD numeric strings to ``int``; sentinels → ``None``."""
+    f = _to_float(value)
+    return int(f) if f is not None else None
+
+
+def _to_float_list(value: Any) -> list[float]:
+    """Coerce a list of numeric strings to ``list[float]``; drop sentinels."""
+    if not isinstance(value, list):
+        return []
+    out: list[float] = []
+    for item in value:
+        f = _to_float(item)
+        if f is not None:
+            out.append(f)
+    return out
+
+
+def _strip_middot(value: Any) -> Any:
+    """Drop the ``·`` (middle-dot) the BYD cloud injects into unit strings.
+
+    HA-friendly unit strings drop the middot — ``kW·h/100km`` becomes
+    ``kWh/100km``. Applied to every unit field on this endpoint so the
+    realtime and energy models surface a single normalized form.
+    """
+    if isinstance(value, str):
+        return value.replace("·", "")
+    return value
+
+
+_BydFloat = Annotated[float | None, BeforeValidator(_to_float)]
+_BydInt = Annotated[int | None, BeforeValidator(_to_int)]
+_BydFloatList = Annotated[list[float], BeforeValidator(_to_float_list)]
+_BydUnit = Annotated[str, BeforeValidator(_strip_middot)]
+
+
+class EnergyConsumptionGraph(BydBaseModel):
+    """7-day rolling consumption series.
+
+    Used for both ``selfGraph`` (this vehicle) and ``autoModelGraph``
+    (model-average comparison). The unit reflects whichever leg matches
+    the request's ``powerType`` — ``kW·h/100km`` for ``"0"``, ``L/100km``
+    for ``"1"``/``"2"``.
+    """
+
+    energy_consumption: _BydFloatList = Field(default_factory=list)
+    energy_consumption_unit: _BydUnit = ""
+
+
+class CumulativeEnergyConsumption(BydBaseModel):
+    """Lifetime cumulative consumption, per leg.
+
+    Both legs are populated for hybrids when ``powerType="2"``; pure-EV
+    or pure-ICE responses leave the unused leg empty.
+    """
+
+    total_mileage: _BydFloat = None
+    mileage_unit: _BydUnit = ""
+    avg_ev_consumption: _BydFloat = None
+    """Average EV consumption (kWh/100km)."""
+    ev_unit: _BydUnit = ""
+    avg_oil_consumption: _BydFloat = None
+    """Average petrol consumption (L/100km)."""
+    oil_unit: _BydUnit = ""
+
+
+class NearestEnergyConsumption(BydBaseModel):
+    """Last-50km breakdown, per leg + driving-mode distribution."""
+
+    avg_ev_consumption: _BydFloat = None
+    """Average EV consumption over the last 50km (kWh/100km)."""
+    ev_consumption: _BydFloat = None
+    """Total EV energy used over the last 50km (kWh)."""
+    ev_unit: _BydUnit = ""
+    ev_value_unit: _BydUnit = ""
+
+    avg_oil_consumption: _BydFloat = None
+    """Average petrol consumption over the last 50km (L/100km)."""
+    oil_consumption: _BydFloat = None
+    """Total petrol used over the last 50km (L)."""
+    oil_unit: _BydUnit = ""
+    oil_value_unit: _BydUnit = ""
+
+    avg_eq_oil_consumption: _BydFloat = None
+    """Equivalent petrol consumption — EV usage expressed in L/100km."""
+
+    drive_distribution: _BydInt = None
+    """Percentage of the last 50km in normal drive mode."""
+    elect_distribution: _BydInt = None
+    """Percentage of the last 50km on electric power."""
+    air_distribution: _BydInt = None
+    """Percentage of the last 50km with HVAC active."""
+    other_distribution: _BydInt = None
+    """Percentage of the last 50km in other modes."""
 
 
 class EnergyConsumption(BydBaseModel):
-    """Energy consumption data for a vehicle."""
+    """Energy consumption data for a vehicle.
 
-    vin: str = ""
-    total_energy: float | None = None
-    avg_energy_consumption: float | None = None
-    electricity_consumption: float | None = None
-    fuel_consumption: float | None = None
+    Mirrors the four-section response of
+    ``/vehicleInfo/vehicle/getEnergyConsumption``.
+    """
+
+    _KEY_ALIASES: ClassVar[dict[str, str]] = {
+        "time": "timestamp",
+    }
+
+    self_graph: EnergyConsumptionGraph | None = None
+    cumulative_energy_consumption: CumulativeEnergyConsumption | None = None
+    nearest_energy_consumption: NearestEnergyConsumption | None = None
+    auto_model_graph: EnergyConsumptionGraph | None = None
+    timestamp: BydTimestamp = None

--- a/src/pybyd/models/realtime.py
+++ b/src/pybyd/models/realtime.py
@@ -5,10 +5,14 @@ Enum values and field meanings are documented in API_MAPPING.md.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any, ClassVar
 
+from pydantic import ValidationInfo, model_validator
+
 from pybyd.models._base import COMMON_KEY_ALIASES, BydBaseModel, BydEnum, BydTimestamp, is_negative, is_temp_sentinel
+from pybyd.models.vehicle import EnergyType
 
 # ------------------------------------------------------------------
 # Enums
@@ -152,6 +156,193 @@ class AirCirculationMode(BydEnum):
     UNAVAILABLE = 0
     EXTERNAL = 1
     INTERNAL = 2
+
+
+# ------------------------------------------------------------------
+# Hybrid energy/consumption string splitting
+# ------------------------------------------------------------------
+#
+# Several realtime fields combine EV and ICE data when the per-vehicle
+# ``EnergyType`` is :attr:`EnergyType.HYBRID`. The shape varies per field:
+#
+#     EnergyType.EV                 EnergyType.ICE                    EnergyType.HYBRID (combined)
+#     ─────────────────────────     ─────────────────────────         ──────────────────────────
+#     "6.1"                         "8.4"                             "6.1+8.4"
+#     "6.1kW·h/100km"               "3.5L/100km"                      "6.1kW·h/100km+8.4L/100km"
+#     "19.7kW·h/100km"              "3.5L/100km"                      "(19.7kW·h+3.5L)/100km"
+#     "10.1" (kW·h/100km)           "--"                              "10.1" (L/100km)   ← nearestEnergyConsumption
+#
+# Parsing branches by :class:`EnergyType`:
+#   - EV:     value is single-leg EV
+#   - ICE:    value is single-leg petrol
+#   - HYBRID: value is combined; pull both legs out
+#
+# ``nearestEnergyConsumption`` is special: even at HYBRID the cloud returns
+# a single-leg value, with the unit field disambiguating which leg.
+
+_NUM_RE = re.compile(r"-?\d+(?:\.\d+)?")
+_FUEL_UNIT_RE = re.compile(r"L/100km|升", re.IGNORECASE)
+_EV_UNIT_RE = re.compile(r"kW[·.]?h/100km|度", re.IGNORECASE)
+_SENTINELS = frozenset({"", "--"})
+
+_LegSplit = tuple[str | None, str | None, str | None, str | None]
+
+
+def _first_num(text: str | None) -> float | None:
+    """Extract the first signed decimal in *text* as a float (or None)."""
+    if not text:
+        return None
+    match = _NUM_RE.search(text)
+    return float(match.group()) if match else None
+
+
+def _normalize_unit(text: str | None) -> str | None:
+    """Strip the ``·`` (middle-dot) the BYD cloud injects into unit strings.
+
+    The BYD API sends ``kW·h/100km`` etc.; HA-friendly unit strings drop the
+    middot (``kWh/100km``). Applied to every unit string surfaced from
+    realtime parsing so consumers see a single, normalized form.
+    """
+    if text is None:
+        return None
+    return text.replace("·", "")
+
+
+def _extract_unit(text: str | None) -> str:
+    """Return the substring trailing the leading signed decimal in *text*."""
+    if not text:
+        return ""
+    cleaned = text.strip()
+    match = _NUM_RE.match(cleaned)
+    tail = cleaned if match is None else cleaned[match.end() :].strip()
+    return _normalize_unit(tail) or ""
+
+
+def _classify_two_legs(
+    ev_str: str,
+    fuel_str: str,
+    default_ev_unit: str,
+    default_fuel_unit: str,
+) -> _LegSplit:
+    """Annotate two known leg strings with their unit substrings."""
+    ev_unit = _extract_unit(ev_str) or default_ev_unit
+    fuel_unit = _extract_unit(fuel_str) or default_fuel_unit
+    return ev_str, ev_unit, fuel_str, fuel_unit
+
+
+def _split_combined_string(
+    raw: Any,
+    energy_type: EnergyType,
+    *,
+    default_ev_unit: str = "",
+    default_fuel_unit: str = "",
+) -> _LegSplit:
+    """Split a combined-form consumption string into per-leg (value, unit) pairs.
+
+    Returns ``(ev_value, ev_unit, fuel_value, fuel_unit)``. Each value is a
+    string preserving the original format (units inline where the original
+    had them). The unit is the trailing substring after the leading number,
+    falling back to the supplied default for unit-less inputs.
+
+    Handles three combined shapes plus single-leg fallback:
+
+      - ``"(EVform+Fuelform)/<shared-unit>"`` (e.g. ``"(19.7kW·h+3.5L)/100km"``)
+      - ``"EVform+Fuelform"`` with units inline (e.g. ``"6.1kW·h/100km+8.4L/100km"``)
+      - ``"EVform+Fuelform"`` numeric only (e.g. ``"6.1+8.4"``)
+      - single-leg, classified by embedded unit or ``energy_type``.
+    """
+    if raw is None:
+        return None, None, None, None
+    text = str(raw).strip()
+    if text in _SENTINELS:
+        return None, None, None, None
+
+    if text.startswith("("):
+        close_idx = text.find(")")
+        if close_idx != -1:
+            inside = text[1:close_idx]
+            suffix = text[close_idx + 1 :].lstrip("/").strip()
+            if "+" in inside:
+                left, _, right = inside.partition("+")
+                left, right = left.strip(), right.strip()
+                ev_str = f"{left}/{suffix}" if suffix else left
+                fuel_str = f"{right}/{suffix}" if suffix else right
+                return _classify_two_legs(
+                    ev_str,
+                    fuel_str,
+                    default_ev_unit,
+                    default_fuel_unit,
+                )
+
+    if "+" in text:
+        left, _, right = text.partition("+")
+        left, right = left.strip(), right.strip()
+        # Detect inverse ordering when both halves carry units.
+        if _FUEL_UNIT_RE.search(left) and _EV_UNIT_RE.search(right):
+            return _classify_two_legs(right, left, default_ev_unit, default_fuel_unit)
+        return _classify_two_legs(left, right, default_ev_unit, default_fuel_unit)
+
+    inline_unit = _extract_unit(text)
+    if _FUEL_UNIT_RE.search(text):
+        return None, None, text, inline_unit or default_fuel_unit
+    if _EV_UNIT_RE.search(text):
+        return text, inline_unit or default_ev_unit, None, None
+    if energy_type is EnergyType.ICE:
+        return None, None, text, inline_unit or default_fuel_unit
+    return text, inline_unit or default_ev_unit, None, None
+
+
+def _legacy_leg_alias(
+    ev_value: str | None,
+    fuel_value: str | None,
+    energy_type: EnergyType,
+) -> str | None:
+    """Compute the legacy non-suffixed alias for a per-leg field.
+
+    Returns the EV-leg value when present. For :attr:`EnergyType.HYBRID`
+    where the response carries only the petrol leg (notably
+    ``nearestEnergyConsumption`` at HYBRID), falls back to the fuel value
+    so legacy consumers still see *some* data rather than ``None``.
+    Pure-ICE vehicles (:attr:`EnergyType.ICE`) deliberately do not fall
+    back — their petrol data is exposed exclusively via the ``_fuel``
+    fields.
+    """
+    if ev_value is not None:
+        return ev_value
+    if energy_type is EnergyType.HYBRID:
+        return fuel_value
+    return None
+
+
+def _split_nearest_energy_string(
+    value: Any,
+    unit: Any,
+    energy_type: EnergyType,
+) -> _LegSplit:
+    """Resolve ``nearestEnergyConsumption`` using the paired unit field.
+
+    The cloud only ever returns a single-leg numeric value here; for
+    :attr:`EnergyType.HYBRID` that leg is petrol, with the unit field as
+    the authoritative classifier (``"L/100km"`` vs ``"kWh/100km"``).
+    """
+    if value is None:
+        return None, None, None, None
+    text = str(value).strip()
+    if text in _SENTINELS:
+        return None, None, None, None
+
+    unit_text = str(unit or "").strip() if unit is not None else ""
+    if unit_text in _SENTINELS:
+        unit_text = ""
+    unit_text = _normalize_unit(unit_text) or ""
+
+    if _FUEL_UNIT_RE.search(unit_text):
+        return None, None, text, unit_text
+    if _EV_UNIT_RE.search(unit_text):
+        return text, unit_text, None, None
+    if energy_type is EnergyType.ICE:
+        return None, None, text, unit_text
+    return text, unit_text, None, None
 
 
 # ------------------------------------------------------------------
@@ -404,6 +595,52 @@ class VehicleRealtimeData(BydBaseModel):
     total_consumption_en: str | None = None
     """English-locale total consumption label (e.g. '16.6kW·h/100km')."""
 
+    # --- Hybrid leg breakouts (parsed from combined strings) ---
+    # For each combined-form field, ``_split_hybrid_legs`` populates four
+    # parallel fields: numeric per-leg value plus the per-leg unit string.
+    # The original (non-suffixed) field is also rebound to the EV-portion
+    # string of the original payload as a backwards-compat alias — the raw
+    # combined string remains accessible via ``raw``.
+    energy_consumption_ev: float | None = None
+    energy_consumption_ev_unit: str | None = None
+    energy_consumption_fuel: float | None = None
+    energy_consumption_fuel_unit: str | None = None
+
+    nearest_energy_consumption_ev: float | None = None
+    nearest_energy_consumption_ev_unit: str | None = None
+    nearest_energy_consumption_fuel: float | None = None
+    nearest_energy_consumption_fuel_unit: str | None = None
+
+    recent_50km_energy_ev: float | None = None
+    recent_50km_energy_ev_unit: str | None = None
+    recent_50km_energy_fuel: float | None = None
+    recent_50km_energy_fuel_unit: str | None = None
+
+    total_energy_ev: float | None = None
+    total_energy_ev_unit: str | None = None
+    total_energy_fuel: float | None = None
+    total_energy_fuel_unit: str | None = None
+
+    total_consumption_ev: float | None = None
+    total_consumption_ev_unit: str | None = None
+    total_consumption_fuel: float | None = None
+    total_consumption_fuel_unit: str | None = None
+
+    total_consumption_en_ev: float | None = None
+    total_consumption_en_ev_unit: str | None = None
+    total_consumption_en_fuel: float | None = None
+    total_consumption_en_fuel_unit: str | None = None
+
+    # ``nearestEnergyConsumption`` (raw): a single-number "recent consumption"
+    # summary. The cloud picks whichever metric is most informative for the
+    # vehicle type — pure-EV: avg EV (kW·h/100km); pure-ICE: avg petrol
+    # (L/100km); hybrid: eq-petrol (L/100km, ≈ avgEqOilConsumption from
+    # the getEnergyConsumption endpoint). Preserved here verbatim before the
+    # legacy ``nearest_energy_consumption`` field is rebound for backwards
+    # compat (see ``_split_hybrid_legs``).
+    eq_consumption: float | None = None
+    eq_consumption_unit: str | None = None
+
     # --- Fuel (extended) ---
     oil_pressure_system: int | None = None
     """Oil pressure warning. 0=normal."""
@@ -433,6 +670,167 @@ class VehicleRealtimeData(BydBaseModel):
     # --- Metadata ---
     timestamp: BydTimestamp = None
     """Data timestamp (parsed to UTC datetime)."""
+
+    # ------------------------------------------------------------------
+    # Hybrid leg splitting
+    # ------------------------------------------------------------------
+
+    @model_validator(mode="before")
+    @classmethod
+    def _split_hybrid_legs(cls, values: Any, info: ValidationInfo) -> Any:
+        """Populate ``_ev``/``_ev_unit``/``_fuel``/``_fuel_unit`` per-leg fields
+        and rebind the original (non-suffixed) field to its EV-leg value.
+
+        The original combined string remains accessible via ``raw``. For
+        ``nearestEnergyConsumption``/``nearestEnergyConsumptionUnit`` the
+        legacy fields alias to the EV leg, which is ``None`` for hybrids
+        whose response only carries the petrol leg (use ``..._fuel`` /
+        ``..._fuel_unit`` to read it explicitly).
+        """
+        if not isinstance(values, dict):
+            return values
+        # Stash the raw snapshot now so the rebinding below doesn't destroy
+        # the original combined strings. Parent ``_clean_byd_values`` runs
+        # after and only stashes ``raw`` if absent.
+        if "raw" not in values:
+            values["raw"] = dict(values)
+        ctx = info.context if info is not None else None
+        ctx_value = ctx.get("energy_type") if ctx else None
+        energy_type = ctx_value if isinstance(ctx_value, EnergyType) else EnergyType.EV
+
+        # (raw_key, ev_key, ev_unit_key, fuel_key, fuel_unit_key,
+        #  default_ev_unit, default_fuel_unit)
+        splits = (
+            (
+                "energyConsumption",
+                "energy_consumption_ev",
+                "energy_consumption_ev_unit",
+                "energy_consumption_fuel",
+                "energy_consumption_fuel_unit",
+                "kWh/100km",
+                "L/100km",
+            ),
+            (
+                "recent50kmEnergy",
+                "recent_50km_energy_ev",
+                "recent_50km_energy_ev_unit",
+                "recent_50km_energy_fuel",
+                "recent_50km_energy_fuel_unit",
+                "kWh/100km",
+                "L/100km",
+            ),
+            (
+                "totalEnergy",
+                "total_energy_ev",
+                "total_energy_ev_unit",
+                "total_energy_fuel",
+                "total_energy_fuel_unit",
+                "kWh/100km",
+                "L/100km",
+            ),
+            (
+                "totalConsumption",
+                "total_consumption_ev",
+                "total_consumption_ev_unit",
+                "total_consumption_fuel",
+                "total_consumption_fuel_unit",
+                "度/百公里",
+                "升/百公里",
+            ),
+            (
+                "totalConsumptionEn",
+                "total_consumption_en_ev",
+                "total_consumption_en_ev_unit",
+                "total_consumption_en_fuel",
+                "total_consumption_en_fuel_unit",
+                "kWh/100km",
+                "L/100km",
+            ),
+        )
+
+        for raw_key, ev_k, ev_u_k, fuel_k, fuel_u_k, def_ev_u, def_fuel_u in splits:
+            if raw_key not in values:
+                continue
+            ev_str, ev_u, fuel_str, fuel_u = _split_combined_string(
+                values[raw_key],
+                energy_type,
+                default_ev_unit=def_ev_u,
+                default_fuel_unit=def_fuel_u,
+            )
+            ev_n = _first_num(ev_str)
+            fuel_n = _first_num(fuel_str)
+            if ev_n is not None:
+                values.setdefault(ev_k, ev_n)
+                if ev_u:
+                    values.setdefault(ev_u_k, ev_u)
+            if fuel_n is not None:
+                values.setdefault(fuel_k, fuel_n)
+                if fuel_u:
+                    values.setdefault(fuel_u_k, fuel_u)
+            # Backwards-compat: rebind the original (str) field to the
+            # EV-portion. For HYBRID where the cloud returns only the
+            # petrol leg, fall back to the fuel value so legacy consumers
+            # don't suddenly see ``None``.
+            values[raw_key] = _legacy_leg_alias(ev_str, fuel_str, energy_type)
+
+        if "nearestEnergyConsumption" in values:
+            # Capture the raw single-number "recent consumption" summary
+            # before the rebinding below overwrites the legacy field.
+            raw_eq = _first_num(str(values.get("nearestEnergyConsumption") or ""))
+            if raw_eq is not None:
+                values.setdefault("eq_consumption", raw_eq)
+                raw_eq_unit = values.get("nearestEnergyConsumptionUnit")
+                if raw_eq_unit:
+                    values.setdefault(
+                        "eq_consumption_unit",
+                        _normalize_unit(str(raw_eq_unit)),
+                    )
+            ev_str, ev_u, fuel_str, fuel_u = _split_nearest_energy_string(
+                values.get("nearestEnergyConsumption"),
+                values.get("nearestEnergyConsumptionUnit"),
+                energy_type,
+            )
+            # At HYBRID the cloud repurposes nearestEnergyConsumption to
+            # carry the equivalent-petrol consumption (≈ avgEqOilConsumption
+            # in getEnergyConsumption) — *not* the per-leg averages. The
+            # actual nearest EV/fuel averages are packed into energyConsumption
+            # (already split into energy_consumption_ev / _fuel above), so
+            # surface those here. The eq-petrol value remains in raw.
+            if energy_type is EnergyType.HYBRID:
+                ec_ev = values.get("energy_consumption_ev")
+                ec_fuel = values.get("energy_consumption_fuel")
+                ec_ev_u = values.get("energy_consumption_ev_unit")
+                ec_fuel_u = values.get("energy_consumption_fuel_unit")
+                if ec_ev is not None:
+                    ev_str = str(ec_ev)
+                    ev_u = ec_ev_u or "kWh/100km"
+                if ec_fuel is not None:
+                    fuel_str = str(ec_fuel)
+                    fuel_u = ec_fuel_u or "L/100km"
+            ev_n = _first_num(ev_str)
+            fuel_n = _first_num(fuel_str)
+            if ev_n is not None:
+                values.setdefault("nearest_energy_consumption_ev", ev_n)
+                if ev_u:
+                    values.setdefault("nearest_energy_consumption_ev_unit", ev_u)
+            if fuel_n is not None:
+                values.setdefault("nearest_energy_consumption_fuel", fuel_n)
+                if fuel_u:
+                    values.setdefault("nearest_energy_consumption_fuel_unit", fuel_u)
+            # Backwards-compat: legacy value/unit fields alias the EV leg,
+            # falling back to the fuel leg for hybrids that carry only petrol.
+            values["nearestEnergyConsumption"] = _legacy_leg_alias(
+                ev_str,
+                fuel_str,
+                energy_type,
+            )
+            values["nearestEnergyConsumptionUnit"] = _legacy_leg_alias(
+                ev_u,
+                fuel_u,
+                energy_type,
+            )
+
+        return values
 
     # ------------------------------------------------------------------
     # Static helpers

--- a/src/pybyd/models/smart_charging.py
+++ b/src/pybyd/models/smart_charging.py
@@ -1,35 +1,199 @@
-"""Smart charging schedule model."""
+"""Smart charging schedule model.
+
+Populated from ``/control/smartCharge/homePage``.  The endpoint returns
+two nested DTOs that describe the user's configured schedules:
+
+* ``smartChargeDto`` — the simple "charge between X and Y" schedule
+* ``smartJourneyDto`` — the departure-time / off-peak-window schedule
+
+Both DTOs use ``HH:MM`` time-of-day strings on the wire (no seconds).
+``endChargeTime`` may also be the sentinel ``"full"`` meaning *charge
+until the battery is full within the start-time window*.
+
+The ``chargeWay`` field selects how often the schedule repeats:
+
+* ``"s"`` — single one-shot charge
+* ``"e"`` — every day
+* ``"0,1,2,3,4"`` — comma-separated weekday indices (``0`` = Monday)
+
+See ``captures/logs_decrypted/timetable_set_*`` for reference payloads.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+from datetime import time
+from typing import Annotated, Any, ClassVar
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BeforeValidator, model_validator
+
+from pybyd.models._base import BydBaseModel, BydTimestamp
 
 
-class SmartChargingSchedule(BaseModel):
-    """Charging schedule configuration for a vehicle."""
+def _parse_hhmm(value: Any) -> time | None:
+    """Parse a BYD ``HH:MM`` time-of-day string to :class:`datetime.time`.
 
-    model_config = ConfigDict(frozen=True)
+    Returns ``None`` for sentinel-like inputs (the base validator already
+    drops ``""`` / ``"--"``, but ``"full"`` is endpoint-specific and
+    handled separately on :pyattr:`SmartChargeDto.charge_until_full`).
+    """
+    if value is None or isinstance(value, time):
+        return value if isinstance(value, time) else None
+    text = str(value).strip()
+    if not text or text.lower() == "full":
+        return None
+    parts = text.split(":")
+    if len(parts) < 2:
+        return None
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+        second = int(parts[2]) if len(parts) >= 3 else 0
+    except ValueError:
+        return None
+    if not (0 <= hour <= 23 and 0 <= minute <= 59 and 0 <= second <= 59):
+        return None
+    return time(hour=hour, minute=minute, second=second)
 
-    vin: str
-    """Vehicle Identification Number."""
-    target_soc: int | None
-    """Target state of charge (0-100 percent)."""
-    start_hour: int | None
-    """Scheduled charge start hour (0-23)."""
-    start_minute: int | None
-    """Scheduled charge start minute (0-59)."""
-    end_hour: int | None
-    """Scheduled charge end hour (0-23)."""
-    end_minute: int | None
-    """Scheduled charge end minute (0-59)."""
-    smart_charge_switch: int | None
-    """Smart charge toggle state (0=off, 1=on)."""
-    raw: dict[str, Any]
-    """Full API response dict."""
+
+def _parse_status_bool(value: Any) -> bool | None:
+    """Parse the BYD status string (``"1"``/``"0"``) to ``bool``."""
+    if value is None or isinstance(value, bool):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    return text == "1"
+
+
+def _parse_charge_way(value: Any) -> str | None:
+    """Pass through ``chargeWay`` as-is — interpretation lives on the model."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+_HhmmTime = Annotated[time | None, BeforeValidator(_parse_hhmm)]
+_StatusBool = Annotated[bool | None, BeforeValidator(_parse_status_bool)]
+_ChargeWay = Annotated[str | None, BeforeValidator(_parse_charge_way)]
+
+
+class SmartChargeDto(BydBaseModel):
+    """The simple "charge within a window" schedule (``smartChargeDto``).
+
+    ``end_time`` is ``None`` when the wire value is the ``"full"`` sentinel —
+    use :pyattr:`charge_until_full` to distinguish that from "no schedule".
+    """
+
+    _KEY_ALIASES: ClassVar[dict[str, str]] = {
+        "startChargeTime": "start_time",
+        "endChargeTime": "end_time",
+    }
+
+    start_time: _HhmmTime = None
+    end_time: _HhmmTime = None
+    charge_until_full: bool = False
+    """``True`` when ``endChargeTime`` was the wire sentinel ``"full"``."""
+    charge_way: _ChargeWay = None
+    status: _StatusBool = None
+    update_time: BydTimestamp = None
+    create_time: BydTimestamp = None
+    exe_time: BydTimestamp = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _capture_charge_until_full(cls, values: Any) -> Any:
+        """Set ``chargeUntilFull=True`` when wire ``endChargeTime`` is ``"full"``.
+
+        Runs alongside :meth:`BydBaseModel._clean_byd_values` (pydantic
+        chains inherited ``mode="before"`` validators) — keeping this as
+        a separate validator avoids overriding the parent and the
+        descriptor-proxy mypy complaint that comes with calling
+        ``super()._clean_byd_values(...)``.  The ``"full"`` token isn't
+        in the base sentinel set, so it survives the cleaning pass and
+        is still visible here.
+        """
+        if isinstance(values, dict):
+            raw_end = values.get("endChargeTime")
+            if isinstance(raw_end, str) and raw_end.strip().lower() == "full":
+                values = dict(values)
+                values["chargeUntilFull"] = True
+        return values
 
     @property
     def is_enabled(self) -> bool:
-        """Whether smart charging is currently enabled."""
-        return self.smart_charge_switch is not None and self.smart_charge_switch == 1
+        """Whether the schedule is currently active."""
+        return self.status is True
+
+    @property
+    def repeat_days(self) -> list[int] | None:
+        """Parsed weekday indices for ``chargeWay``, when applicable.
+
+        Returns ``None`` for the named modes (``"s"`` single, ``"e"`` every
+        day) and for empty/unknown values.  Returns a list of ``int`` for
+        explicit weekday selections like ``"0,1,2,3,4"`` (``0`` = Monday).
+        """
+        cw = self.charge_way
+        if not cw or cw in ("s", "e"):
+            return None
+        try:
+            return [int(p.strip()) for p in cw.split(",") if p.strip()]
+        except ValueError:
+            return None
+
+
+class SmartJourneyDto(BydBaseModel):
+    """Departure-time / off-peak-window schedule (``smartJourneyDto``).
+
+    ``use_vehicle_time`` is when the vehicle should be ready;
+    ``start_discount_price`` / ``end_discount_price`` define the off-peak
+    tariff window the charger will prefer.
+    """
+
+    _KEY_ALIASES: ClassVar[dict[str, str]] = {
+        "useVehicleTime": "use_vehicle_time",
+        "startDiscountPrice": "discount_start",
+        "endDiscountPrice": "discount_end",
+    }
+
+    use_vehicle_time: _HhmmTime = None
+    discount_start: _HhmmTime = None
+    discount_end: _HhmmTime = None
+    charge_way: _ChargeWay = None
+    status: _StatusBool = None
+    update_time: BydTimestamp = None
+    create_time: BydTimestamp = None
+
+    @property
+    def is_enabled(self) -> bool:
+        """Whether the journey schedule is currently active."""
+        return self.status is True
+
+
+class SmartChargingSchedule(BydBaseModel):
+    """Top-level schedule snapshot from ``/control/smartCharge/homePage``.
+
+    Composes the two nested DTOs plus the response-level metadata
+    (``vehicleTimeZone``, ``soc``, ``type``).
+    """
+
+    _KEY_ALIASES: ClassVar[dict[str, str]] = {
+        "smartChargeDto": "charge",
+        "smartJourneyDto": "journey",
+        "vehicleTimeZone": "time_zone",
+    }
+
+    vin: str = ""
+    soc: int | None = None
+    type: str | None = None
+    time_zone: str | None = None
+    charge: SmartChargeDto | None = None
+    journey: SmartJourneyDto | None = None
+    update_time: BydTimestamp = None
+
+    @property
+    def is_enabled(self) -> bool:
+        """Whether *any* schedule is currently active."""
+        return (self.charge is not None and self.charge.is_enabled) or (
+            self.journey is not None and self.journey.is_enabled
+        )

--- a/src/pybyd/models/vehicle.py
+++ b/src/pybyd/models/vehicle.py
@@ -6,7 +6,23 @@ from typing import ClassVar
 
 from pydantic import Field, model_validator
 
-from pybyd.models._base import BydBaseModel, BydTimestamp
+from pybyd.models._base import BydBaseModel, BydEnum, BydTimestamp
+
+
+class EnergyType(BydEnum):
+    """Vehicle powertrain type.
+
+    Maps to the BYD API's ``energyType`` (per-vehicle attribute) and
+    ``powerType`` (request field on ``getEnergyConsumption``). The cloud
+    transports the value as a string-encoded integer (``"0"`` / ``"1"`` /
+    ``"2"``) — call sites converting to the wire format use
+    ``str(int(value))``.
+    """
+
+    UNKNOWN = -1
+    EV = 0
+    ICE = 1
+    HYBRID = 2
 
 
 class EmpowerRange(BydBaseModel):
@@ -28,7 +44,7 @@ class Vehicle(BydBaseModel):
     vin: str = ""
     model_name: str = ""
     brand_name: str = ""
-    energy_type: str = ""
+    energy_type: EnergyType = EnergyType.UNKNOWN
     auto_alias: str = ""
     auto_plate: str = ""
     pic_main_url: str = ""

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -12,6 +12,7 @@ from pybyd._validators import (
 )
 from pybyd.models.gps import GpsInfo
 from pybyd.models.realtime import LockState, VehicleRealtimeData
+from pybyd.models.vehicle import EnergyType
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -382,3 +383,320 @@ class TestApplyRealtimePreserveWhenNone:
         filtered = apply_realtime_filters(previous, incoming)
 
         assert getattr(filtered, field_name) == incoming_value
+
+
+# ---------------------------------------------------------------------------
+# Hybrid leg splitting (energy_type-aware parsing)
+# ---------------------------------------------------------------------------
+
+
+class TestEnergyTypeLegSplit:
+    """VehicleRealtimeData parses combined consumption strings into _ev/_fuel
+    sub-fields, branching on the energy_type validation context."""
+
+    def test_et0_ev_only(self) -> None:
+        m = VehicleRealtimeData.model_validate(
+            {
+                "energyConsumption": "6.1",
+                "nearestEnergyConsumption": "6.1",
+                "nearestEnergyConsumptionUnit": "kW·h/100km",
+                "recent50kmEnergy": "6.1kW·h/100km",
+                "totalEnergy": "19.7kW·h/100km",
+                "totalConsumptionEn": "19.7kW·h/100km",
+            },
+            context={"energy_type": EnergyType.EV},
+        )
+        assert m.energy_consumption_ev == 6.1
+        assert m.energy_consumption_fuel is None
+        assert m.nearest_energy_consumption_ev == 6.1
+        assert m.nearest_energy_consumption_fuel is None
+        assert m.recent_50km_energy_ev == 6.1
+        assert m.recent_50km_energy_fuel is None
+        assert m.total_energy_ev == 19.7
+        assert m.total_energy_fuel is None
+        assert m.total_consumption_en_ev == 19.7
+        assert m.total_consumption_en_fuel is None
+
+    def test_et1_fuel_only_routes_bare_numbers_to_fuel(self) -> None:
+        m = VehicleRealtimeData.model_validate(
+            {
+                "energyConsumption": "8.4",
+                "totalConsumptionEn": "3.5L/100km",
+            },
+            context={"energy_type": EnergyType.ICE},
+        )
+        assert m.energy_consumption_ev is None
+        assert m.energy_consumption_fuel == 8.4
+        assert m.total_consumption_en_ev is None
+        assert m.total_consumption_en_fuel == 3.5
+
+    def test_et2_combined_splits_both_legs(self) -> None:
+        m = VehicleRealtimeData.model_validate(
+            {
+                "energyConsumption": "6.1+8.4",
+                "recent50kmEnergy": "6.1kW·h/100km+8.4L/100km",
+                "totalEnergy": "19.7kW·h/100km+3.5L/100km",
+                "totalConsumptionEn": "(19.7kW·h+3.5L)/100km",
+            },
+            context={"energy_type": EnergyType.HYBRID},
+        )
+        assert (m.energy_consumption_ev, m.energy_consumption_fuel) == (6.1, 8.4)
+        assert (m.recent_50km_energy_ev, m.recent_50km_energy_fuel) == (6.1, 8.4)
+        assert (m.total_energy_ev, m.total_energy_fuel) == (19.7, 3.5)
+        assert (m.total_consumption_en_ev, m.total_consumption_en_fuel) == (19.7, 3.5)
+
+    def test_et2_nearest_uses_unit_field_to_classify(self) -> None:
+        """At energy_type=2 the cloud returns a single-leg petrol value here;
+        the unit field 'L/100km' is the authoritative classifier."""
+        m = VehicleRealtimeData.model_validate(
+            {
+                "nearestEnergyConsumption": "10.1",
+                "nearestEnergyConsumptionUnit": "L/100km",
+            },
+            context={"energy_type": EnergyType.HYBRID},
+        )
+        assert m.nearest_energy_consumption_ev is None
+        assert m.nearest_energy_consumption_fuel == 10.1
+
+    def test_no_context_defaults_to_ev(self) -> None:
+        """Bare numeric without context falls back to EV (preserves
+        backwards-compatible behaviour for callers not passing context)."""
+        m = VehicleRealtimeData.model_validate({"energyConsumption": "6.1"})
+        assert m.energy_consumption_ev == 6.1
+        assert m.energy_consumption_fuel is None
+
+    def test_sentinel_value_yields_no_legs(self) -> None:
+        m = VehicleRealtimeData.model_validate(
+            {"energyConsumption": "--"},
+            context={"energy_type": EnergyType.HYBRID},
+        )
+        assert m.energy_consumption_ev is None
+        assert m.energy_consumption_fuel is None
+
+    def test_unit_companion_strings_populated(self) -> None:
+        """Each per-leg float has a parallel ``_unit`` string."""
+        m = VehicleRealtimeData.model_validate(
+            {
+                "energyConsumption": "6.1+8.4",
+                "totalEnergy": "19.7kW·h/100km+3.5L/100km",
+                "totalConsumptionEn": "(19.7kW·h+3.5L)/100km",
+                "totalConsumption": "(19.7度+3.5升)/百公里",
+            },
+            context={"energy_type": EnergyType.HYBRID},
+        )
+        assert m.energy_consumption_ev_unit == "kWh/100km"
+        assert m.energy_consumption_fuel_unit == "L/100km"
+        assert m.total_energy_ev_unit == "kWh/100km"
+        assert m.total_energy_fuel_unit == "L/100km"
+        assert m.total_consumption_en_ev_unit == "kWh/100km"
+        assert m.total_consumption_en_fuel_unit == "L/100km"
+        assert m.total_consumption_ev_unit == "度/百公里"
+        assert m.total_consumption_fuel_unit == "升/百公里"
+
+    def test_legacy_field_aliases_to_ev_portion(self) -> None:
+        """The legacy non-suffixed string field is rebound to the
+        EV-portion of the original combined string for backwards compat;
+        the full combined string remains in ``raw``."""
+        m = VehicleRealtimeData.model_validate(
+            {
+                "energyConsumption": "6.1+8.4",
+                "totalEnergy": "19.7kW·h/100km+3.5L/100km",
+                "totalConsumptionEn": "(19.7kW·h+3.5L)/100km",
+            },
+            context={"energy_type": EnergyType.HYBRID},
+        )
+        # Legacy aliases hold the EV-portion only
+        assert m.energy_consumption == "6.1"
+        assert m.total_energy == "19.7kW·h/100km"
+        assert m.total_consumption_en == "19.7kW·h/100km"
+        # Original combined strings preserved in raw
+        assert m.raw["energyConsumption"] == "6.1+8.4"
+        assert m.raw["totalConsumptionEn"] == "(19.7kW·h+3.5L)/100km"
+
+    def test_et2_nearest_derives_per_leg_from_energy_consumption(self) -> None:
+        """At energy_type=2, ``nearestEnergyConsumption`` carries the
+        equivalent-petrol number (matches ``avgEqOilConsumption`` in
+        getEnergyConsumption). The actual per-leg nearest averages are
+        packed into ``energyConsumption`` (`"6.1+8.4"`), and the parser
+        surfaces those into ``nearest_energy_consumption_ev/_fuel`` so
+        backwards-compat is preserved (legacy alias picks up the EV leg)."""
+        m = VehicleRealtimeData.model_validate(
+            {
+                "energyConsumption": "6.1+8.4",
+                "nearestEnergyConsumption": "10.1",
+                "nearestEnergyConsumptionUnit": "L/100km",
+            },
+            context={"energy_type": EnergyType.HYBRID},
+        )
+        # Per-leg fields derive from energyConsumption, not the eq-oil number
+        assert m.nearest_energy_consumption_ev == 6.1
+        assert m.nearest_energy_consumption_ev_unit == "kWh/100km"
+        assert m.nearest_energy_consumption_fuel == 8.4
+        assert m.nearest_energy_consumption_fuel_unit == "L/100km"
+        # Legacy alias matches the et=0 EV-value behaviour
+        assert m.nearest_energy_consumption == "6.1"
+        assert m.nearest_energy_consumption_unit == "kWh/100km"
+        # Eq-petrol value still recoverable via raw
+        assert m.raw["nearestEnergyConsumption"] == "10.1"
+
+    def test_et2_nearest_falls_back_to_fuel_when_no_energy_consumption(self) -> None:
+        """If energyConsumption is missing (degenerate hybrid response), the
+        legacy alias falls back to the petrol leg via the existing rule."""
+        m = VehicleRealtimeData.model_validate(
+            {
+                "nearestEnergyConsumption": "10.1",
+                "nearestEnergyConsumptionUnit": "L/100km",
+            },
+            context={"energy_type": EnergyType.HYBRID},
+        )
+        assert m.nearest_energy_consumption_ev is None
+        assert m.nearest_energy_consumption_fuel == 10.1
+        assert m.nearest_energy_consumption == "10.1"
+        assert m.nearest_energy_consumption_unit == "L/100km"
+
+    def test_legacy_alias_does_not_fall_back_for_pure_ice(self) -> None:
+        """Pure-ICE vehicles (energy_type=1) keep legacy aliases as None —
+        their petrol data is exposed exclusively via _fuel fields."""
+        m = VehicleRealtimeData.model_validate(
+            {"energyConsumption": "8.4"},
+            context={"energy_type": EnergyType.ICE},
+        )
+        assert m.energy_consumption_fuel == 8.4
+        assert m.energy_consumption is None
+
+
+# ---------------------------------------------------------------------------
+# EnergyConsumption — getEnergyConsumption response parsing
+# ---------------------------------------------------------------------------
+
+
+from pybyd.models.energy import EnergyConsumption  # noqa: E402
+
+
+class TestEnergyConsumptionParsing:
+    """Parse the four-section getEnergyConsumption response.
+
+    Fixtures mirror the real captures in
+    captures/logs_decrypted/force_energy_{0,1,2}/.
+    """
+
+    PT0_RAW = {
+        "selfGraph": {
+            "energyConsumption": ["8.3", "8.4", "8.0", "8.0", "8.7", "10.1", "6.1"],
+            "energyConsumptionUnit": "kWh/100km",
+        },
+        "cumulativeEnergyConsumption": {
+            "mileageUnit": "km",
+            "evUnit": "kWh/100km",
+            "avgOilConsumption": "--",
+            "avgEvConsumption": "19.7",
+            "oilUnit": "--",
+            "totalMileage": "443",
+        },
+        "time": 1778212356,
+        "nearestEnergyConsumption": {
+            "driveDistribution": "99",
+            "otherDistribution": "0",
+            "evConsumption": "3.05",
+            "electDistribution": "1",
+            "avgOilConsumption": "--",
+            "evValueUnit": "kW·h",
+            "airDistribution": "0",
+            "avgEvConsumption": "6.1",
+            "avgEqOilConsumption": "--",
+            "oilUnit": "--",
+            "evUnit": "kWh/100km",
+            "oilConsumption": "--",
+            "oilValueUnit": "--",
+        },
+        "autoModelGraph": {
+            "energyConsumption": ["0", "0", "0", "0", "0", "0", "0"],
+            "energyConsumptionUnit": "kWh/100km",
+        },
+    }
+
+    PT2_RAW = {
+        "selfGraph": {
+            "energyConsumption": ["8.3", "8.4", "8.0", "8.0", "8.7", "10.1", "10.1"],
+            "energyConsumptionUnit": "L/100km",
+        },
+        "cumulativeEnergyConsumption": {
+            "mileageUnit": "km",
+            "evUnit": "kWh/100km",
+            "avgOilConsumption": "3.5",
+            "avgEvConsumption": "19.7",
+            "oilUnit": "L/100km",
+            "totalMileage": "443",
+        },
+        "time": 1778212356,
+        "nearestEnergyConsumption": {
+            "driveDistribution": "99",
+            "otherDistribution": "0",
+            "evConsumption": "3.05",
+            "electDistribution": "1",
+            "avgOilConsumption": "8.4",
+            "evValueUnit": "kW·h",
+            "airDistribution": "0",
+            "avgEvConsumption": "6.1",
+            "avgEqOilConsumption": "10.1",
+            "oilUnit": "L/100km",
+            "evUnit": "kWh/100km",
+            "oilConsumption": "4.2",
+            "oilValueUnit": "L",
+        },
+        "autoModelGraph": {
+            "energyConsumption": ["8.3", "8.3", "8.3", "8.2", "8.2", "8.4", "8.4"],
+            "energyConsumptionUnit": "L/100km",
+        },
+    }
+
+    def test_pt0_ev_view(self) -> None:
+        m = EnergyConsumption.model_validate(self.PT0_RAW)
+        assert m.self_graph is not None
+        assert m.self_graph.energy_consumption == [8.3, 8.4, 8.0, 8.0, 8.7, 10.1, 6.1]
+        assert m.self_graph.energy_consumption_unit == "kWh/100km"
+        assert m.cumulative_energy_consumption is not None
+        assert m.cumulative_energy_consumption.avg_ev_consumption == 19.7
+        assert m.cumulative_energy_consumption.avg_oil_consumption is None
+        assert m.cumulative_energy_consumption.total_mileage == 443.0
+        assert m.nearest_energy_consumption is not None
+        assert m.nearest_energy_consumption.avg_ev_consumption == 6.1
+        assert m.nearest_energy_consumption.ev_consumption == 3.05
+        assert m.nearest_energy_consumption.avg_oil_consumption is None
+        assert m.nearest_energy_consumption.drive_distribution == 99
+        assert m.nearest_energy_consumption.elect_distribution == 1
+        assert m.timestamp is not None
+
+    def test_pt2_hybrid_view(self) -> None:
+        m = EnergyConsumption.model_validate(self.PT2_RAW)
+        c = m.cumulative_energy_consumption
+        assert c is not None
+        assert c.avg_ev_consumption == 19.7
+        assert c.avg_oil_consumption == 3.5
+        assert c.ev_unit == "kWh/100km"
+        assert c.oil_unit == "L/100km"
+        n = m.nearest_energy_consumption
+        assert n is not None
+        assert (n.avg_ev_consumption, n.avg_oil_consumption) == (6.1, 8.4)
+        assert (n.ev_consumption, n.oil_consumption) == (3.05, 4.2)
+        assert n.avg_eq_oil_consumption == 10.1
+        g = m.auto_model_graph
+        assert g is not None
+        assert g.energy_consumption == [8.3, 8.3, 8.3, 8.2, 8.2, 8.4, 8.4]
+
+    def test_sentinel_strings_become_none(self) -> None:
+        """`"--"` numeric sentinels become None on the parsed fields."""
+        m = EnergyConsumption.model_validate(
+            {"cumulativeEnergyConsumption": {"avgOilConsumption": "--", "avgEvConsumption": "--"}}
+        )
+        assert m.cumulative_energy_consumption is not None
+        assert m.cumulative_energy_consumption.avg_ev_consumption is None
+        assert m.cumulative_energy_consumption.avg_oil_consumption is None
+
+    def test_empty_payload_yields_empty_sections(self) -> None:
+        m = EnergyConsumption.model_validate({})
+        assert m.self_graph is None
+        assert m.cumulative_energy_consumption is None
+        assert m.nearest_energy_consumption is None
+        assert m.auto_model_graph is None
+        assert m.timestamp is None


### PR DESCRIPTION
## Summary

- New `SmartChargingSchedule` model parsed from `/control/smartCharge/homePage` (`smartChargeDto` + `smartJourneyDto`).  Time fields are `datetime.time`, `charge_until_full` flags the `"full"` end-time sentinel, `charge_way` token has a `repeat_days` helper for comma-separated weekday selections.  ISO-8601 strings now also parse via `parse_byd_timestamp`.
- New `charging_schedule` section on `VehicleSnapshot` + matching state-engine plumbing (`update_charging_schedule`, projection overlay).
- `BydClient.get_charging_homepage` returns `(ChargingStatus, SmartChargingSchedule)` from one HTTP call so a force-refresh updates both views together; `BydCar.update_charging` writes both sections.  MQTT pushes still flow through `engine.update_charging` with a partial `ChargingStatus` so schedule fields can't be clobbered by realtime pushes.
- `save_charging_schedule` reworked to use `_trigger_and_poll` (`saveOrUpdate` → `changeResult`) — same `functionNo 1012` / `RESERVATIONCHARGING` gate as `start_charging`, returns `ChargeChangeResult`, refreshes snapshot via `update_charging` on terminal success.  Wire format matches captured BYD-app traffic (`startChargeTime` / `endChargeTime` as `HH:MM` or the `"full"` sentinel, `chargeWay`, `status`) — the prior int-hour/minute/SoC shape was unverified and didn't match the wire.
- BYD code `6002` ("weak network signal around the vehicle") maps to `BydDataUnavailableError` via `extra_code_map` so callers can surface a cleaner message than the raw "endpoint failed: code=6002 …".

## Dependency

⚠️ **Built on top of #36** (per-vehicle energyType wiring + hybrid leg parsing) — the diff against `main` includes those commits.  Once #36 lands this PR will rebase to a single smart-charging commit.

## Test plan

- [ ] All pyBYD tests pass locally
- [ ] Live cloud round-trip via `BydClient.get_charging_homepage` returns both views from one HTTP call
- [ ] `BydClient.save_charging_schedule` confirmed against the running vehicle (start/end times applied, `changeResult` polled to terminal)
- [ ] BYD code 6002 surfaces as `BydDataUnavailableError` rather than generic `BydApiError`