### PR TITLE
feat: TrunkCapability (OPENTRUNK / CLOSETRUNK)

### DIFF
--- a/src/pybyd/_capabilities/trunk.py
+++ b/src/pybyd/_capabilities/trunk.py
@@ -1,0 +1,72 @@
+"""Trunk open/close capability."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pybyd.exceptions import BydEndpointNotSupportedError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+class TrunkCapability:
+    """Open and close the trunk remotely.
+
+    Like :class:`FinderCapability`, these are fire-and-forget commands
+    without an observable projection, so no state projections are
+    registered.
+    """
+
+    def __init__(
+        self,
+        *,
+        open_fn: Callable[..., Awaitable[Any]],
+        close_fn: Callable[..., Awaitable[Any]],
+        vin: str,
+        execute_command: Callable[..., Awaitable[None]],
+        open_available: bool | None = True,
+        close_available: bool | None = True,
+    ) -> None:
+        self._open_fn = open_fn
+        self._close_fn = close_fn
+        self._vin = vin
+        self._execute = execute_command
+        self._open_available = open_available
+        self._close_available = close_available
+
+    @property
+    def open_available(self) -> bool:
+        return bool(self._open_available)
+
+    @property
+    def close_available(self) -> bool:
+        return bool(self._close_available)
+
+    async def open(self) -> None:
+        """Open (release the latch of) the trunk."""
+        if not self.open_available:
+            raise BydEndpointNotSupportedError(
+                f"Open-trunk capability not supported for VIN {self._vin}",
+                code="capability_unsupported",
+                endpoint="trunk.open",
+            )
+
+        async def _cmd() -> Any:
+            return await self._open_fn(self._vin)
+
+        await self._execute(_cmd, [])
+
+    async def close(self) -> None:
+        """Close (electrically lower) the trunk."""
+        if not self.close_available:
+            raise BydEndpointNotSupportedError(
+                f"Close-trunk capability not supported for VIN {self._vin}",
+                code="capability_unsupported",
+                endpoint="trunk.close",
+            )
+
+        async def _cmd() -> Any:
+            return await self._close_fn(self._vin)
+
+        await self._execute(_cmd, [])

--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -33,6 +33,7 @@ from pybyd._capabilities.hvac import HvacCapability
 from pybyd._capabilities.lock import LockCapability
 from pybyd._capabilities.seat import SeatCapability
 from pybyd._capabilities.steering import SteeringCapability
+from pybyd._capabilities.trunk import TrunkCapability
 from pybyd._capabilities.windows import WindowsCapability
 from pybyd._state_engine import ProjectionSpec, VehicleSnapshot, VehicleStateEngine
 from pybyd.exceptions import BydRemoteControlError
@@ -166,6 +167,14 @@ class BydCar:
             vin=vin,
             execute_command=self._execute_command,
             close_available=self._capabilities.close_windows,
+        )
+        self.trunk = TrunkCapability(
+            open_fn=client.open_trunk,
+            close_fn=client.close_trunk,
+            vin=vin,
+            execute_command=self._execute_command,
+            open_available=self._capabilities.open_trunk,
+            close_available=self._capabilities.close_trunk,
         )
 
     # ------------------------------------------------------------------

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1319,6 +1319,34 @@ class BydClient:
         pwd = self._require_command_pwd(command_pwd)
         return await self._remote_control(vin, RemoteCommand.FIND_CAR, command_pwd=pwd)
 
+    async def open_trunk(
+        self,
+        vin: str,
+        *,
+        command_pwd: str | None = None,
+    ) -> RemoteControlResult:
+        """Open (release) the trunk remotely.
+
+        Maps to ``commandType=OPENTRUNK`` and gated by functionNo ``1020``
+        (code ``OPENTRUNK``) in Latest Config.
+        """
+        pwd = self._require_command_pwd(command_pwd)
+        return await self._remote_control(vin, RemoteCommand.OPEN_TRUNK, command_pwd=pwd)
+
+    async def close_trunk(
+        self,
+        vin: str,
+        *,
+        command_pwd: str | None = None,
+    ) -> RemoteControlResult:
+        """Close (lower) the trunk remotely.
+
+        Maps to ``commandType=CLOSETRUNK`` and gated by functionNo ``1021``
+        (code ``CLOSETRUNK``) in Latest Config.
+        """
+        pwd = self._require_command_pwd(command_pwd)
+        return await self._remote_control(vin, RemoteCommand.CLOSE_TRUNK, command_pwd=pwd)
+
     async def schedule_climate(
         self,
         vin: str,

--- a/src/pybyd/models/command_gating.py
+++ b/src/pybyd/models/command_gating.py
@@ -107,6 +107,20 @@ _COMMAND_GATE_RULES: tuple[CommandGateRule, ...] = (
     ),
     CommandGateRule.model_validate(
         {
+            "gateId": "open_trunk",
+            "command": RemoteCommand.OPEN_TRUNK,
+            "requiredFunctionNos": ["1020"],
+        }
+    ),
+    CommandGateRule.model_validate(
+        {
+            "gateId": "close_trunk",
+            "command": RemoteCommand.CLOSE_TRUNK,
+            "requiredFunctionNos": ["1021"],
+        }
+    ),
+    CommandGateRule.model_validate(
+        {
             "gateId": "seat_driver",
             "command": RemoteCommand.SEAT_CLIMATE,
             "requiredFunctionNos": ["10030001", "10030002", "10300003"],

--- a/src/pybyd/models/control.py
+++ b/src/pybyd/models/control.py
@@ -37,6 +37,8 @@ class RemoteCommand(enum.StrEnum):
     CLOSE_WINDOWS = "CLOSEWINDOW"
     SEAT_CLIMATE = "VENTILATIONHEATING"
     BATTERY_HEAT = "BATTERYHEAT"
+    OPEN_TRUNK = "OPENTRUNK"
+    CLOSE_TRUNK = "CLOSETRUNK"
     # `START_CHARGE` is a synthetic value (never sent on the wire as a
     # `commandType`).  The on-the-wire smart-charging "start" toggle goes via
     # `/control/smartCharge/changeChargeStatue` with ``status: "1"`` rather

--- a/src/pybyd/models/latest_config.py
+++ b/src/pybyd/models/latest_config.py
@@ -104,6 +104,8 @@ class VehicleCapabilities(BydBaseModel):
     flash_lights: bool | None = None
     close_windows: bool | None = None
     location: bool | None = None
+    open_trunk: bool | None = None
+    close_trunk: bool | None = None
 
     function_nos: list[str] = Field(default_factory=list)
     codes: list[str] = Field(default_factory=list)
@@ -153,6 +155,8 @@ class VehicleCapabilities(BydBaseModel):
                 "flash_lights": require(["1008"]),
                 "close_windows": require(["1026"]),
                 "location": require(["1014"]),
+                "open_trunk": require(["1020"]),
+                "close_trunk": require(["1021"]),
                 "function_nos": sorted(function_nos),
                 "codes": sorted(normalized_codes),
                 "unknown_function_nos": unknown_function_nos,


### PR DESCRIPTION
Add support for the trunk open/close remote commands.  Mirrors the
existing `FinderCapability` shape (fire-and-forget, no projections).

## Why

Several VINs advertise trunk-control capabilities in their Latest Config
that pyBYD currently does not surface:

| functionNo | code        | functionName                       |
|------------|-------------|------------------------------------|
| `1020`     | `OPENTRUNK` | 解锁后备箱 (unlock / release trunk)|
| `1021`     | `CLOSETRUNK`| 关闭后备箱 (close trunk)           |

Without these wired through, downstream integrations (HACS / ioBroker)
have no path to expose "Open trunk" buttons even on cars that fully
support the feature.

## What changed

- `RemoteCommand.OPEN_TRUNK` / `CLOSE_TRUNK` enum members
- `BydClient.open_trunk()` / `close_trunk()` thin wrappers over
  `_remote_control()` (same shape as `flash_lights`, `close_windows`)
- New `TrunkCapability` (`open()`, `close()`) following
  `FinderCapability` conventions
- `VehicleCapabilities.open_trunk` / `close_trunk` derived from
  `function_nos` (`1020` / `1021`)
- Two new `_COMMAND_GATE_RULES` entries (`open_trunk` / `close_trunk`)
- `BydCar.trunk` exposed alongside the other capabilities

## Verification

- All 112 existing tests pass.
- Lint passes (`black`, `ruff`, `mypy`).
- Tested end-to-end against a real **BYD Sealion 7 Comfort 2024 EU**
  which advertises both `functionNo`s.  Installed this branch in a
  Docker HA dev container via `pybyd @ git+...@feat/trunk-capability`;
  `coordinator.capability_available("open_trunk")` returns `True` and
  the buttons appear in the HACS integration.  Physical-actuation
  test (clicking the button and observing the trunk move) is the
  remaining unknown — I'll comment here once I confirm the
  `commandType=OPENTRUNK` payload is accepted by the cloud.  If the
  cloud rejects it, this PR will need adjusting to the actual command
  name (the code names `OPENTRUNK` / `CLOSETRUNK` from Latest Config
  are the best-known guess given pyBYD's existing naming convention).

## Convention used

The wire `commandType` values match the Latest Config `code` exactly
(`OPENTRUNK` / `CLOSETRUNK`).  This is consistent with
`FLASHLIGHTNOWHISTLE`, `FINDCAR`, and (modulo plural→singular)
`CLOSEWINDOWS → CLOSEWINDOW`.

Happy to adjust if you have MITM captures of the BYD app that show a
different naming.

---

Part of broader Sealion 7 EU compatibility work documented in
[pyBYD#20](https://github.com/jkaberg/pyBYD/issues/20).  Follow-up PR
for One-Tap Prep / Shutdown commands coming next once the trunk PR is
either merged or the naming convention confirmed.