### PR TITLE
feat: OneTapCapability (ONETAPPREP / ONECLICKSHUTDOWN) [payload unverified]

### DIFF
--- a/src/pybyd/_capabilities/one_tap.py
+++ b/src/pybyd/_capabilities/one_tap.py
@@ -1,0 +1,100 @@
+"""One-tap pre-conditioning and shutdown capability.
+
+These capabilities are a best-effort wrapper around the
+``ONETAPPREP`` and ``ONECLICKSHUTDOWN`` ``commandType`` values that
+appear in the BYD Latest Config under ``functionNo`` ``1030`` and
+``1031`` respectively.
+
+> **WARNING: command payload is unverified.**
+>
+> Unlike ``LOCKDOOR`` / ``OPENAIR`` etc., we do not yet have a captured
+> request body from the BYD app for these commands.  This module
+> currently sends them as fire-and-forget (no ``controlParams``), based
+> on the assumption that the cloud derives the sub-system selection
+> (A/C + seats + steering wheel heat) from per-VIN profile settings
+> rather than from request params.
+>
+> If the cloud returns a ``code=1001`` / ``code=1009`` error when
+> invoking either of these, the most likely fix is to add a typed
+> ``OneTapParams`` model with the appropriate per-feature flags.  The
+> Latest Config sub-codes that hint at the schema:
+>   - ``10300001`` (A/C)
+>   - ``10300003`` (Seats)
+>   - ``10300004`` (Steering wheel heat)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pybyd.exceptions import BydEndpointNotSupportedError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+class OneTapCapability:
+    """One-tap pre-conditioning (``ONETAPPREP``) and shutdown
+    (``ONECLICKSHUTDOWN``) commands.
+
+    Implemented as fire-and-forget mirrors of :class:`FinderCapability`
+    until the exact payload schema is reverse-engineered.
+    """
+
+    def __init__(
+        self,
+        *,
+        prep_fn: Callable[..., Awaitable[Any]],
+        shutdown_fn: Callable[..., Awaitable[Any]],
+        vin: str,
+        execute_command: Callable[..., Awaitable[None]],
+        prep_available: bool | None = True,
+        shutdown_available: bool | None = True,
+    ) -> None:
+        self._prep_fn = prep_fn
+        self._shutdown_fn = shutdown_fn
+        self._vin = vin
+        self._execute = execute_command
+        self._prep_available = prep_available
+        self._shutdown_available = shutdown_available
+
+    @property
+    def prep_available(self) -> bool:
+        return bool(self._prep_available)
+
+    @property
+    def shutdown_available(self) -> bool:
+        return bool(self._shutdown_available)
+
+    async def prep(self) -> None:
+        """Start the configured pre-conditioning profile.
+
+        Sends ``commandType=ONETAPPREP`` with no ``controlParams``.  The
+        car-side profile (which seats, target temperature, steering wheel
+        heat) is assumed to be configured per-VIN via the BYD app.
+        """
+        if not self.prep_available:
+            raise BydEndpointNotSupportedError(
+                f"One-tap prep capability not supported for VIN {self._vin}",
+                code="capability_unsupported",
+                endpoint="one_tap.prep",
+            )
+
+        async def _cmd() -> Any:
+            return await self._prep_fn(self._vin)
+
+        await self._execute(_cmd, [])
+
+    async def shutdown(self) -> None:
+        """Shut down any active pre-conditioning (``ONECLICKSHUTDOWN``)."""
+        if not self.shutdown_available:
+            raise BydEndpointNotSupportedError(
+                f"One-tap shutdown capability not supported for VIN {self._vin}",
+                code="capability_unsupported",
+                endpoint="one_tap.shutdown",
+            )
+
+        async def _cmd() -> Any:
+            return await self._shutdown_fn(self._vin)
+
+        await self._execute(_cmd, [])

--- a/src/pybyd/_version.py
+++ b/src/pybyd/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '0.0.63.dev0+gd0b200769.d20260406'
-__version_tuple__ = version_tuple = (0, 0, 63, 'dev0', 'gd0b200769.d20260406')
+__version__ = version = '0.1.dev2+ge0a1f5e27'
+__version_tuple__ = version_tuple = (0, 1, 'dev2', 'ge0a1f5e27')
 
 __commit_id__ = commit_id = None

--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -31,6 +31,7 @@ from pybyd._capabilities.battery_heat import BatteryHeatCapability
 from pybyd._capabilities.finder import FinderCapability
 from pybyd._capabilities.hvac import HvacCapability
 from pybyd._capabilities.lock import LockCapability
+from pybyd._capabilities.one_tap import OneTapCapability
 from pybyd._capabilities.seat import SeatCapability
 from pybyd._capabilities.steering import SteeringCapability
 from pybyd._capabilities.windows import WindowsCapability
@@ -166,6 +167,14 @@ class BydCar:
             vin=vin,
             execute_command=self._execute_command,
             close_available=self._capabilities.close_windows,
+        )
+        self.one_tap = OneTapCapability(
+            prep_fn=client.one_tap_prep,
+            shutdown_fn=client.one_tap_shutdown,
+            vin=vin,
+            execute_command=self._execute_command,
+            prep_available=self._capabilities.one_tap_prep,
+            shutdown_available=self._capabilities.one_tap_shutdown,
         )
 
     # ------------------------------------------------------------------

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1319,6 +1319,35 @@ class BydClient:
         pwd = self._require_command_pwd(command_pwd)
         return await self._remote_control(vin, RemoteCommand.FIND_CAR, command_pwd=pwd)
 
+    async def one_tap_prep(
+        self,
+        vin: str,
+        *,
+        command_pwd: str | None = None,
+    ) -> RemoteControlResult:
+        """Start the configured one-tap pre-conditioning profile.
+
+        Maps to ``commandType=ONETAPPREP`` and gated by functionNo
+        ``1030`` in Latest Config.  Sends no ``controlParams`` (see
+        ``one_tap.py`` docstring for the unverified-payload caveat).
+        """
+        pwd = self._require_command_pwd(command_pwd)
+        return await self._remote_control(vin, RemoteCommand.ONE_TAP_PREP, command_pwd=pwd)
+
+    async def one_tap_shutdown(
+        self,
+        vin: str,
+        *,
+        command_pwd: str | None = None,
+    ) -> RemoteControlResult:
+        """Shut down any active one-tap pre-conditioning.
+
+        Maps to ``commandType=ONECLICKSHUTDOWN`` and gated by functionNo
+        ``1031`` in Latest Config.
+        """
+        pwd = self._require_command_pwd(command_pwd)
+        return await self._remote_control(vin, RemoteCommand.ONE_TAP_SHUTDOWN, command_pwd=pwd)
+
     async def schedule_climate(
         self,
         vin: str,

--- a/src/pybyd/models/command_gating.py
+++ b/src/pybyd/models/command_gating.py
@@ -107,6 +107,20 @@ _COMMAND_GATE_RULES: tuple[CommandGateRule, ...] = (
     ),
     CommandGateRule.model_validate(
         {
+            "gateId": "one_tap_prep",
+            "command": RemoteCommand.ONE_TAP_PREP,
+            "requiredFunctionNos": ["1030"],
+        }
+    ),
+    CommandGateRule.model_validate(
+        {
+            "gateId": "one_tap_shutdown",
+            "command": RemoteCommand.ONE_TAP_SHUTDOWN,
+            "requiredFunctionNos": ["1031"],
+        }
+    ),
+    CommandGateRule.model_validate(
+        {
             "gateId": "seat_driver",
             "command": RemoteCommand.SEAT_CLIMATE,
             "requiredFunctionNos": ["10030001", "10030002", "10300003"],

--- a/src/pybyd/models/control.py
+++ b/src/pybyd/models/control.py
@@ -37,6 +37,12 @@ class RemoteCommand(enum.StrEnum):
     CLOSE_WINDOWS = "CLOSEWINDOW"
     SEAT_CLIMATE = "VENTILATIONHEATING"
     BATTERY_HEAT = "BATTERYHEAT"
+    # One-Tap Prep / Shutdown — `commandType` is the best guess from the
+    # Latest Config `code` field; correct payload structure (with or
+    # without controlParams) is TBD pending live testing.  See the
+    # OneTapCapability docstring.
+    ONE_TAP_PREP = "ONETAPPREP"
+    ONE_TAP_SHUTDOWN = "ONECLICKSHUTDOWN"
     # `START_CHARGE` is a synthetic value (never sent on the wire as a
     # `commandType`).  The on-the-wire smart-charging "start" toggle goes via
     # `/control/smartCharge/changeChargeStatue` with ``status: "1"`` rather

--- a/src/pybyd/models/latest_config.py
+++ b/src/pybyd/models/latest_config.py
@@ -32,6 +32,7 @@ def registered_latest_config_function_nos() -> frozenset[str]:
             "1004",  # tire pressure (parent)
             "1014",  # location
             "1030",  # one-tap prep (parent)
+            "1031",  # one-click shutdown
             "10020001",  # sunroof
             "10020002",  # hood
             "10020003",  # trunk
@@ -104,6 +105,8 @@ class VehicleCapabilities(BydBaseModel):
     flash_lights: bool | None = None
     close_windows: bool | None = None
     location: bool | None = None
+    one_tap_prep: bool | None = None
+    one_tap_shutdown: bool | None = None
 
     function_nos: list[str] = Field(default_factory=list)
     codes: list[str] = Field(default_factory=list)
@@ -153,6 +156,8 @@ class VehicleCapabilities(BydBaseModel):
                 "flash_lights": require(["1008"]),
                 "close_windows": require(["1026"]),
                 "location": require(["1014"]),
+                "one_tap_prep": require(["1030"]),
+                "one_tap_shutdown": require(["1031"]),
                 "function_nos": sorted(function_nos),
                 "codes": sorted(normalized_codes),
                 "unknown_function_nos": unknown_function_nos,


### PR DESCRIPTION
Adds support for the one-tap pre-conditioning (`ONETAPPREP`,
functionNo `1030`) and one-tap shutdown (`ONECLICKSHUTDOWN`,
functionNo `1031`) remote commands.

## ⚠️ Draft because payload is unverified

Unlike the trunk PR (#41), I don't have a captured request body from
the BYD app for these commands.  This module sends them as
fire-and-forget (no `controlParams`), based on the hypothesis that the
cloud derives sub-system selection from per-VIN profile settings.

If the cloud returns `code=1001` / `code=1009`, the fix is likely a
typed `OneTapParams` model with sub-system flags corresponding to the
Latest Config sub-codes:
- `10300001` — A/C
- `10300003` — Seats
- `10300004` — Steering wheel heat

Marking as draft so the structure can be reviewed without committing
to the payload shape.  I'll graduate it to "ready for review" once I
confirm the invocation against my own VIN (Sealion 7 Comfort 2024
EU, which advertises both `1030` and `1031`).

## What changed

- `RemoteCommand.ONE_TAP_PREP` / `ONE_TAP_SHUTDOWN` enum members
- `BydClient.one_tap_prep()` / `one_tap_shutdown()` thin wrappers
- New `OneTapCapability` mirroring `FinderCapability`
- `VehicleCapabilities.one_tap_prep` / `one_tap_shutdown` flags
- Two new `_COMMAND_GATE_RULES` entries
- `BydCar.one_tap` exposed alongside the other capabilities
- `1031` (one-click shutdown) added to
  `registered_latest_config_function_nos()`

## Verification status

- ✅ All 112 existing tests pass
- ✅ Lint (black, ruff, mypy)
- ✅ Capability flags resolve correctly against a real Sealion 7 EU
- ⏳ Physical actuation test — will report back here

Companion to #41 (TrunkCapability).  Both came out of the broader
inventory in [pyBYD#20](https://github.com/jkaberg/pyBYD/issues/20).