### PR TITLE
feat: TrunkCapability (OPENTRUNK / CLOSETRUNK)

### DIFF
--- a/src/pybyd/_capabilities/trunk.py
+++ b/src/pybyd/_capabilities/trunk.py
@@ -1,0 +1,72 @@
+"""Trunk open/close capability."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pybyd.exceptions import BydEndpointNotSupportedError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+class TrunkCapability:
+    """Open and close the trunk remotely.
+
+    Like :class:`FinderCapability`, these are fire-and-forget commands
+    without an observable projection, so no state projections are
+    registered.
+    """
+
+    def __init__(
+        self,
+        *,
+        open_fn: Callable[..., Awaitable[Any]],
+        close_fn: Callable[..., Awaitable[Any]],
+        vin: str,
+        execute_command: Callable[..., Awaitable[None]],
+        open_available: bool | None = True,
+        close_available: bool | None = True,
+    ) -> None:
+        self._open_fn = open_fn
+        self._close_fn = close_fn
+        self._vin = vin
+        self._execute = execute_command
+        self._open_available = open_available
+        self._close_available = close_available
+
+    @property
+    def open_available(self) -> bool:
+        return bool(self._open_available)
+
+    @property
+    def close_available(self) -> bool:
+        return bool(self._close_available)
+
+    async def open(self) -> None:
+        """Open (release the latch of) the trunk."""
+        if not self.open_available:
+            raise BydEndpointNotSupportedError(
+                f"Open-trunk capability not supported for VIN {self._vin}",
+                code="capability_unsupported",
+                endpoint="trunk.open",
+            )
+
+        async def _cmd() -> Any:
+            return await self._open_fn(self._vin)
+
+        await self._execute(_cmd, [])
+
+    async def close(self) -> None:
+        """Close (electrically lower) the trunk."""
+        if not self.close_available:
+            raise BydEndpointNotSupportedError(
+                f"Close-trunk capability not supported for VIN {self._vin}",
+                code="capability_unsupported",
+                endpoint="trunk.close",
+            )
+
+        async def _cmd() -> Any:
+            return await self._close_fn(self._vin)
+
+        await self._execute(_cmd, [])

--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -33,6 +33,7 @@ from pybyd._capabilities.hvac import HvacCapability
 from pybyd._capabilities.lock import LockCapability
 from pybyd._capabilities.seat import SeatCapability
 from pybyd._capabilities.steering import SteeringCapability
+from pybyd._capabilities.trunk import TrunkCapability
 from pybyd._capabilities.windows import WindowsCapability
 from pybyd._state_engine import ProjectionSpec, VehicleSnapshot, VehicleStateEngine
 from pybyd.exceptions import BydRemoteControlError
@@ -166,6 +167,14 @@ class BydCar:
             vin=vin,
             execute_command=self._execute_command,
             close_available=self._capabilities.close_windows,
+        )
+        self.trunk = TrunkCapability(
+            open_fn=client.open_trunk,
+            close_fn=client.close_trunk,
+            vin=vin,
+            execute_command=self._execute_command,
+            open_available=self._capabilities.open_trunk,
+            close_available=self._capabilities.close_trunk,
         )
 
     # ------------------------------------------------------------------

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1319,6 +1319,34 @@ class BydClient:
         pwd = self._require_command_pwd(command_pwd)
         return await self._remote_control(vin, RemoteCommand.FIND_CAR, command_pwd=pwd)
 
+    async def open_trunk(
+        self,
+        vin: str,
+        *,
+        command_pwd: str | None = None,
+    ) -> RemoteControlResult:
+        """Open (release) the trunk remotely.
+
+        Maps to ``commandType=OPENTRUNK`` and gated by functionNo ``1020``
+        (code ``OPENTRUNK``) in Latest Config.
+        """
+        pwd = self._require_command_pwd(command_pwd)
+        return await self._remote_control(vin, RemoteCommand.OPEN_TRUNK, command_pwd=pwd)
+
+    async def close_trunk(
+        self,
+        vin: str,
+        *,
+        command_pwd: str | None = None,
+    ) -> RemoteControlResult:
+        """Close (lower) the trunk remotely.
+
+        Maps to ``commandType=CLOSETRUNK`` and gated by functionNo ``1021``
+        (code ``CLOSETRUNK``) in Latest Config.
+        """
+        pwd = self._require_command_pwd(command_pwd)
+        return await self._remote_control(vin, RemoteCommand.CLOSE_TRUNK, command_pwd=pwd)
+
     async def schedule_climate(
         self,
         vin: str,

--- a/src/pybyd/models/command_gating.py
+++ b/src/pybyd/models/command_gating.py
@@ -107,6 +107,20 @@ _COMMAND_GATE_RULES: tuple[CommandGateRule, ...] = (
     ),
     CommandGateRule.model_validate(
         {
+            "gateId": "open_trunk",
+            "command": RemoteCommand.OPEN_TRUNK,
+            "requiredFunctionNos": ["1020"],
+        }
+    ),
+    CommandGateRule.model_validate(
+        {
+            "gateId": "close_trunk",
+            "command": RemoteCommand.CLOSE_TRUNK,
+            "requiredFunctionNos": ["1021"],
+        }
+    ),
+    CommandGateRule.model_validate(
+        {
             "gateId": "seat_driver",
             "command": RemoteCommand.SEAT_CLIMATE,
             "requiredFunctionNos": ["10030001", "10030002", "10300003"],

--- a/src/pybyd/models/control.py
+++ b/src/pybyd/models/control.py
@@ -37,6 +37,8 @@ class RemoteCommand(enum.StrEnum):
     CLOSE_WINDOWS = "CLOSEWINDOW"
     SEAT_CLIMATE = "VENTILATIONHEATING"
     BATTERY_HEAT = "BATTERYHEAT"
+    OPEN_TRUNK = "OPENTRUNK"
+    CLOSE_TRUNK = "CLOSETRUNK"
     # `START_CHARGE` is a synthetic value (never sent on the wire as a
     # `commandType`).  The on-the-wire smart-charging "start" toggle goes via
     # `/control/smartCharge/changeChargeStatue` with ``status: "1"`` rather

--- a/src/pybyd/models/latest_config.py
+++ b/src/pybyd/models/latest_config.py
@@ -104,6 +104,8 @@ class VehicleCapabilities(BydBaseModel):
     flash_lights: bool | None = None
     close_windows: bool | None = None
     location: bool | None = None
+    open_trunk: bool | None = None
+    close_trunk: bool | None = None
 
     function_nos: list[str] = Field(default_factory=list)
     codes: list[str] = Field(default_factory=list)
@@ -153,6 +155,8 @@ class VehicleCapabilities(BydBaseModel):
                 "flash_lights": require(["1008"]),
                 "close_windows": require(["1026"]),
                 "location": require(["1014"]),
+                "open_trunk": require(["1020"]),
+                "close_trunk": require(["1021"]),
                 "function_nos": sorted(function_nos),
                 "codes": sorted(normalized_codes),
                 "unknown_function_nos": unknown_function_nos,


### PR DESCRIPTION
Re-opens PR #41 with physical confirmation that the commands work on a real BYD Sealion 7 Comfort 2024 (EU spec, VIN starting LGXCH4CD4S, T-Box version 3).

### What

Adds `RemoteCommand.OPEN_TRUNK` / `CLOSE_TRUNK` (wire strings `OPENTRUNK` / `CLOSETRUNK`) + matching `TrunkCapability`, gated by Latest Config function numbers `1020` (open) / `1021` (close).

Follows the same fire-and-forget shape as `FinderCapability` — no projections, since trunk-state updates arrive asynchronously via the regular realtime/MQTT pipeline.

### Live validation

Tested on 2026-05-19 via a HACS-installed `hass-byd-vehicle` fork pinned to this branch:

- `button.byd_sealion_7_open_trunk` → trunk opens physically ✅
- `button.byd_sealion_7_close_trunk` → trunk closes physically ✅
- No `RemoteControlResult` errors, no cloud rejection codes
- Latest Config `function_nos` `1020` and `1021` both present on the test VIN — gating verified end-to-end

### Why now (re-open)

Original PR #41 was closed before live verification — I'd merged the change locally but hadn't pressed the button on the actual car. Now confirmed working, so re-submitting for upstream review.

### Files changed

- `src/pybyd/_capabilities/trunk.py` (new)
- `src/pybyd/models/control.py` — enum members
- `src/pybyd/models/command_gating.py` — gate rules
- `src/pybyd/models/latest_config.py` — capability flags + registered function_nos
- `src/pybyd/client.py` — thin client methods
- `src/pybyd/car.py` — wire `self.trunk` capability

No new dependencies. No breaking changes.