### PR TITLE
feat: OPEN_WINDOWS vent mode (~10% crack)

### DIFF
--- a/src/pybyd/_capabilities/windows.py
+++ b/src/pybyd/_capabilities/windows.py
@@ -11,10 +11,15 @@ if TYPE_CHECKING:
 
 
 class WindowsCapability:
-    """Window close command.
+    """Window open/close commands.
 
-    Close-windows is a fire-and-forget command.  No projections are
+    Both directions are fire-and-forget.  No projections are
     registered because window state updates arrive asynchronously.
+
+    Open is binary (all windows fully open) on the standard
+    ``OPENWINDOW`` endpoint.  Partial position / vent-mode is not
+    supported here; see ``openWindowSignalLearnInfo`` in latest config
+    for a variant flag that might gate a separate command.
     """
 
     def __init__(
@@ -24,15 +29,23 @@ class WindowsCapability:
         vin: str,
         execute_command: Callable[..., Awaitable[None]],
         close_available: bool | None = True,
+        open_fn: Callable[..., Awaitable[Any]] | None = None,
+        open_available: bool | None = True,
     ) -> None:
         self._close_fn = close_fn
+        self._open_fn = open_fn
         self._vin = vin
         self._execute = execute_command
         self._close_available = close_available
+        self._open_available = open_available
 
     @property
     def close_available(self) -> bool:
         return bool(self._close_available)
+
+    @property
+    def open_available(self) -> bool:
+        return bool(self._open_available and self._open_fn is not None)
 
     async def close(self) -> None:
         """Close all windows."""
@@ -45,5 +58,19 @@ class WindowsCapability:
 
         async def _cmd() -> Any:
             return await self._close_fn(self._vin)
+
+        await self._execute(_cmd, [])
+
+    async def open(self) -> None:
+        """Open all windows (fully)."""
+        if not self.open_available or self._open_fn is None:
+            raise BydEndpointNotSupportedError(
+                f"Open-windows capability not supported for VIN {self._vin}",
+                code="capability_unsupported",
+                endpoint="windows.open",
+            )
+
+        async def _cmd() -> Any:
+            return await self._open_fn(self._vin)  # type: ignore[misc]
 
         await self._execute(_cmd, [])

--- a/src/pybyd/_capabilities/windows.py
+++ b/src/pybyd/_capabilities/windows.py
@@ -16,10 +16,12 @@ class WindowsCapability:
     Both directions are fire-and-forget.  No projections are
     registered because window state updates arrive asynchronously.
 
-    Open is binary (all windows fully open) on the standard
-    ``OPENWINDOW`` endpoint.  Partial position / vent-mode is not
-    supported here; see ``openWindowSignalLearnInfo`` in latest config
-    for a variant flag that might gate a separate command.
+    Open behaviour confirmed on Sealion 7 (EU, 2024):  ``OPENWINDOW``
+    cracks the windows to ~10 % (vent mode), **not** 100 %.  This is
+    BYD's native ventilation flow — useful for cooling a sun-baked
+    cabin without committing to fully dropping the glass.  There is
+    no known remote command to fully drop the windows; the physical
+    button switches in the car are the only path for that.
     """
 
     def __init__(
@@ -62,7 +64,11 @@ class WindowsCapability:
         await self._execute(_cmd, [])
 
     async def open(self) -> None:
-        """Open all windows (fully)."""
+        """Crack all windows to ~10 % (vent mode).
+
+        See the class docstring for the live-verified behaviour — this
+        is **not** a full-drop, just BYD's stock ventilation crack.
+        """
         if not self.open_available or self._open_fn is None:
             raise BydEndpointNotSupportedError(
                 f"Open-windows capability not supported for VIN {self._vin}",

--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -163,9 +163,11 @@ class BydCar:
         )
         self.windows = WindowsCapability(
             close_fn=client.close_windows,
+            open_fn=client.open_windows,
             vin=vin,
             execute_command=self._execute_command,
             close_available=self._capabilities.close_windows,
+            open_available=self._capabilities.open_windows,
         )
 
     # ------------------------------------------------------------------

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1309,6 +1309,22 @@ class BydClient:
         pwd = self._require_command_pwd(command_pwd)
         return await self._remote_control(vin, RemoteCommand.CLOSE_WINDOWS, command_pwd=pwd)
 
+    async def open_windows(
+        self,
+        vin: str,
+        *,
+        command_pwd: str | None = None,
+    ) -> RemoteControlResult:
+        """Open all windows fully.
+
+        Binary fire-and-forget. Partial position (vent-mode / N % open)
+        is not supported on this endpoint as far as we know — see
+        ``openWindowSignalLearnInfo`` in latest config for the variant
+        flag that might gate it; capture BYD app traffic to confirm.
+        """
+        pwd = self._require_command_pwd(command_pwd)
+        return await self._remote_control(vin, RemoteCommand.OPEN_WINDOWS, command_pwd=pwd)
+
     async def find_car(
         self,
         vin: str,

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1315,12 +1315,12 @@ class BydClient:
         *,
         command_pwd: str | None = None,
     ) -> RemoteControlResult:
-        """Open all windows fully.
+        """Crack all windows to ~10 % (vent mode).
 
-        Binary fire-and-forget. Partial position (vent-mode / N % open)
-        is not supported on this endpoint as far as we know — see
-        ``openWindowSignalLearnInfo`` in latest config for the variant
-        flag that might gate it; capture BYD app traffic to confirm.
+        Live-verified on Sealion 7 (EU, 2024).  ``OPENWINDOW`` does not
+        fully drop the windows — it opens them to a vent crack of
+        roughly 10 %, BYD's native ventilation behaviour for cooling
+        a sun-baked cabin.  No remote command for a full-drop is known.
         """
         pwd = self._require_command_pwd(command_pwd)
         return await self._remote_control(vin, RemoteCommand.OPEN_WINDOWS, command_pwd=pwd)

--- a/src/pybyd/models/command_gating.py
+++ b/src/pybyd/models/command_gating.py
@@ -105,6 +105,18 @@ _COMMAND_GATE_RULES: tuple[CommandGateRule, ...] = (
             "requiredFunctionNos": ["1026"],
         }
     ),
+    # Open windows shares the windows feature gate.  If `1026` is present
+    # the car supports both directions on this endpoint as far as we know.
+    # Latest-config also exposes finer-grained signals — `10020005` ("windows"
+    # generic) and `openWindowSignalLearnInfo` — that may distinguish full
+    # vs. ventilation variants once we learn more about them.
+    CommandGateRule.model_validate(
+        {
+            "gateId": "open_windows",
+            "command": RemoteCommand.OPEN_WINDOWS,
+            "requiredFunctionNos": ["1026"],
+        }
+    ),
     CommandGateRule.model_validate(
         {
             "gateId": "seat_driver",

--- a/src/pybyd/models/control.py
+++ b/src/pybyd/models/control.py
@@ -35,9 +35,9 @@ class RemoteCommand(enum.StrEnum):
     FIND_CAR = "FINDCAR"
     FLASH_LIGHTS = "FLASHLIGHTNOWHISTLE"
     CLOSE_WINDOWS = "CLOSEWINDOW"
-    # Counterpart to CLOSEWINDOW. The exact wire string is the best guess
-    # from the mirror convention BYD uses elsewhere (OPENTRUNK/CLOSETRUNK,
-    # LOCKDOOR/OPENDOOR). To be validated against live cloud response.
+    # Counterpart to CLOSEWINDOW.  Live-verified on Sealion 7: opens
+    # the windows to a ~10 % vent crack (not full-drop).  BYD's native
+    # ventilation flow; no remote full-drop command is known.
     OPEN_WINDOWS = "OPENWINDOW"
     SEAT_CLIMATE = "VENTILATIONHEATING"
     BATTERY_HEAT = "BATTERYHEAT"

--- a/src/pybyd/models/control.py
+++ b/src/pybyd/models/control.py
@@ -35,6 +35,10 @@ class RemoteCommand(enum.StrEnum):
     FIND_CAR = "FINDCAR"
     FLASH_LIGHTS = "FLASHLIGHTNOWHISTLE"
     CLOSE_WINDOWS = "CLOSEWINDOW"
+    # Counterpart to CLOSEWINDOW. The exact wire string is the best guess
+    # from the mirror convention BYD uses elsewhere (OPENTRUNK/CLOSETRUNK,
+    # LOCKDOOR/OPENDOOR). To be validated against live cloud response.
+    OPEN_WINDOWS = "OPENWINDOW"
     SEAT_CLIMATE = "VENTILATIONHEATING"
     BATTERY_HEAT = "BATTERYHEAT"
     # `START_CHARGE` is a synthetic value (never sent on the wire as a

--- a/src/pybyd/models/latest_config.py
+++ b/src/pybyd/models/latest_config.py
@@ -103,6 +103,7 @@ class VehicleCapabilities(BydBaseModel):
     find_car: bool | None = None
     flash_lights: bool | None = None
     close_windows: bool | None = None
+    open_windows: bool | None = None
     location: bool | None = None
 
     function_nos: list[str] = Field(default_factory=list)
@@ -152,6 +153,7 @@ class VehicleCapabilities(BydBaseModel):
                 "find_car": require(["1007"]),
                 "flash_lights": require(["1008"]),
                 "close_windows": require(["1026"]),
+                "open_windows": require(["1026"]),
                 "location": require(["1014"]),
                 "function_nos": sorted(function_nos),
                 "codes": sorted(normalized_codes),


### PR DESCRIPTION
Adds the counterpart to `CLOSE_WINDOWS` for cracking all windows to BYD's native ventilation position.

### Live validation

Tested on a Sealion 7 Comfort 2024 (EU spec, VIN starting `LGXCH4CD4S`):

- `button.byd_sealion_7_open_windows` → all 4 windows crack to **~10 %** (vent mode) ✅
- `button.byd_sealion_7_close_windows` → re-closes them cleanly (existing pair) ✅
- No cloud rejection, no errors in logs
- Latest Config `function_no=1026` (windows feature) present on the test VIN — gating verified

### Behaviour note

`OPENWINDOW` is **not** a full-drop — it cracks the windows to ~10 % only. This is BYD's native ventilation flow for cooling a sun-baked cabin. There is no known remote command for a full-drop; the physical button switches in the car are the only path for that. Docstrings updated to reflect this.

### Files changed

- `src/pybyd/_capabilities/windows.py` — `WindowsCapability.open()` method
- `src/pybyd/models/control.py` — `RemoteCommand.OPEN_WINDOWS = "OPENWINDOW"` enum value
- `src/pybyd/models/command_gating.py` — gate rule (shares `1026` with close)
- `src/pybyd/models/latest_config.py` — `open_windows` capability flag
- `src/pybyd/client.py` — `BydClient.open_windows()` thin method
- `src/pybyd/car.py` — wire `open_fn` + `open_available` on `WindowsCapability`

No new dependencies. No breaking changes — `WindowsCapability.__init__` adds optional kwargs `open_fn` / `open_available` with safe defaults.

### Related

Builds on the same shape introduced in PR #43 (TrunkCapability). Same fire-and-forget pattern as the existing `close()` direction.