### PR TITLE
fix(timestamps): treat epoch 0 as sentinel, not 1970-01-01

### DIFF
--- a/src/pybyd/models/_base.py
+++ b/src/pybyd/models/_base.py
@@ -87,6 +87,12 @@ def parse_byd_timestamp(value: Any) -> datetime | None:
         ts = int(value)
     except (TypeError, ValueError):
         return None
+    # 0 and negative epochs are sentinels meaning "no value", not literal
+    # epoch-zero (1970-01-01).  The GPS endpoint returns `gpsTimeStamp=0`
+    # while the satellite fix is stale; without this guard the timestamp
+    # surfaces as 1970-01-01 in HA which is worse than `unknown`.
+    if ts <= 0:
+        return None
     if ts >= _MS_THRESHOLD:
         ts = ts // 1000
     return datetime.fromtimestamp(ts, tz=UTC)


### PR DESCRIPTION
### Problem

`parse_byd_timestamp(0)` currently returns `datetime(1970, 1, 1, tzinfo=UTC)`, treating epoch second 0 as a valid timestamp.

The GPS endpoint returns `gpsTimeStamp=0` while the satellite fix is stale (we see this regularly on a Sealion 7 during deep sleep — the cloud holds the last known lat/lon but the timestamp field zeros out). On the consumer side this surfaces as a literal **1970-01-01** value, which is worse than `unknown` — it looks like a real value, breaks `device_class=timestamp` UIs, and can poison downstream automations that compare timestamps.

The actual GPS coordinates remain valid in the same payload; this is purely a sentinel-handling bug.

### Fix

Three-line guard in `parse_byd_timestamp`:

```python
if ts <= 0:
    return None
```

Treat `<= 0` as a sentinel meaning "no value", matching how the rest of the codebase already handles `-1` sentinels (e.g. `is_negative` predicate on `_SENTINEL_RULES` in `realtime.py`).

### Verification

Live test on a Sealion 7 Comfort 2024 (EU): with the fix, `sensor.gps_last_updated` correctly reports `unknown` while the car is in deep sleep (gpsTimeStamp=0), and reports a real UTC datetime once a fresh fix arrives. Without the fix it stays pinned at `1970-01-01T00:00:00+00:00`.

### Files

- `src/pybyd/models/_base.py` — 6 added lines (3 logic + 3 comment) in `parse_byd_timestamp`

No breaking changes; downstream consumers that already handle `None` from this function are unaffected. Pairs with the trunk (PR #43) and open_windows (PR #44) work — same Sealion 7 validation surface.