### PR TITLE
preserve tire_press_unit when HTTP placeholder zeroes pressures

### DIFF
--- a/src/pybyd/_validators.py
+++ b/src/pybyd/_validators.py
@@ -200,6 +200,39 @@ def _apply_model_field_filters(
     return updates
 
 
+_TIRE_PRESSURE_FIELDS: tuple[str, ...] = (
+    "left_front_tire_pressure",
+    "right_front_tire_pressure",
+    "left_rear_tire_pressure",
+    "right_rear_tire_pressure",
+)
+
+
+def _guard_tire_press_unit(
+    previous: VehicleRealtimeData,
+    incoming: VehicleRealtimeData,
+) -> Any | object:
+    """Drop incoming ``tire_press_unit`` when all four pressures are zero.
+
+    The HTTP /vehicleRealTimeResult endpoint returns the realtime block
+    with ``tirePressUnit: 3`` (kPa, the default) and every tire pressure
+    set to ``0`` even when the vehicle is configured for PSI. The tire
+    pressure zero-drop filters already preserve the previous numeric
+    values, but the unit field has no such guard — so the unit flips
+    PSI → kPa while the numeric values stay PSI-scale, and any HA
+    consumer doing unit conversion ends up displaying ``pressure /
+    6.89476`` until the next MQTT push restores the real unit.
+
+    Returns the previous unit when every pressure on *incoming* reads
+    ``0`` / ``None``, or :data:`_MISSING` to leave the incoming value
+    unchanged.
+    """
+    pressures = [getattr(incoming, f, None) for f in _TIRE_PRESSURE_FIELDS]
+    if all(p is None or p == 0 for p in pressures):
+        return getattr(previous, "tire_press_unit", _MISSING)
+    return _MISSING
+
+
 def apply_realtime_filters(
     previous: VehicleRealtimeData | None,
     incoming: VehicleRealtimeData,
@@ -208,6 +241,8 @@ def apply_realtime_filters(
 
     Rules currently include:
     - selected realtime zero-drop gating (doors/locks, SOC/range/tire pressure/odometer).
+    - cross-field guard preserving ``tire_press_unit`` when all four
+      tire pressures on the incoming payload read zero.
 
     The returned model is either:
     - the original incoming payload when no override is needed, or
@@ -215,6 +250,9 @@ def apply_realtime_filters(
     """
     baseline = previous if previous is not None else VehicleRealtimeData.model_validate({})
     updates = _apply_model_field_filters(baseline, incoming, _REALTIME_FIELD_FILTERS)
+    tire_unit_override = _guard_tire_press_unit(baseline, incoming)
+    if tire_unit_override is not _MISSING:
+        updates["tire_press_unit"] = tire_unit_override
     if updates:
         return incoming.model_copy(update=updates)
     return incoming

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -11,7 +11,7 @@ from pybyd._validators import (
     guard_gps_coordinates,
 )
 from pybyd.models.gps import GpsInfo
-from pybyd.models.realtime import LockState, VehicleRealtimeData
+from pybyd.models.realtime import LockState, TirePressureUnit, VehicleRealtimeData
 from pybyd.models.vehicle import EnergyType
 
 # ---------------------------------------------------------------------------
@@ -383,6 +383,108 @@ class TestApplyRealtimePreserveWhenNone:
         filtered = apply_realtime_filters(previous, incoming)
 
         assert getattr(filtered, field_name) == incoming_value
+
+
+class TestApplyRealtimeTirePressUnitGuard:
+    """``tire_press_unit`` is preserved when all four pressures read zero.
+
+    The HTTP /vehicleRealTimeResult endpoint returns ``tirePressUnit: 3``
+    (kPa default) with all pressures set to ``0`` even on vehicles
+    configured for PSI. Without this guard the unit flips PSI → kPa
+    while the numeric pressures stay PSI-scale, so HA's unit conversion
+    divides every reading by ~6.89 until the next MQTT push restores
+    the real unit.
+    """
+
+    def test_zero_pressures_preserve_previous_unit(self) -> None:
+        previous = VehicleRealtimeData.model_validate(
+            {
+                "tirePressUnit": int(TirePressureUnit.PSI),
+                "leftFrontTirepressure": 38.4,
+                "rightFrontTirepressure": 37.2,
+                "leftRearTirepressure": 37.9,
+                "rightRearTirepressure": 37.7,
+            }
+        )
+        incoming = VehicleRealtimeData.model_validate(
+            {
+                "tirePressUnit": int(TirePressureUnit.KPA),
+                "leftFrontTirepressure": 0,
+                "rightFrontTirepressure": 0,
+                "leftRearTirepressure": 0,
+                "rightRearTirepressure": 0,
+            }
+        )
+
+        filtered = apply_realtime_filters(previous, incoming)
+
+        assert filtered.tire_press_unit == TirePressureUnit.PSI
+
+    def test_nonzero_pressures_accept_incoming_unit(self) -> None:
+        previous = VehicleRealtimeData.model_validate(
+            {
+                "tirePressUnit": int(TirePressureUnit.PSI),
+                "leftFrontTirepressure": 38.4,
+                "rightFrontTirepressure": 37.2,
+                "leftRearTirepressure": 37.9,
+                "rightRearTirepressure": 37.7,
+            }
+        )
+        incoming = VehicleRealtimeData.model_validate(
+            {
+                "tirePressUnit": int(TirePressureUnit.KPA),
+                "leftFrontTirepressure": 250.0,
+                "rightFrontTirepressure": 245.0,
+                "leftRearTirepressure": 252.0,
+                "rightRearTirepressure": 248.0,
+            }
+        )
+
+        filtered = apply_realtime_filters(previous, incoming)
+
+        assert filtered.tire_press_unit == TirePressureUnit.KPA
+
+    def test_zero_pressures_first_poll_drops_unit(self) -> None:
+        # Without a previous value the guard falls back to None (matches
+        # the rest of the zero-drop family on first poll: the all-zero
+        # HTTP placeholder is rejected wholesale, including its default
+        # unit).
+        incoming = VehicleRealtimeData.model_validate(
+            {
+                "tirePressUnit": int(TirePressureUnit.KPA),
+                "leftFrontTirepressure": 0,
+                "rightFrontTirepressure": 0,
+                "leftRearTirepressure": 0,
+                "rightRearTirepressure": 0,
+            }
+        )
+
+        filtered = apply_realtime_filters(None, incoming)
+
+        assert filtered.tire_press_unit is None
+
+    def test_partial_pressures_accept_incoming_unit(self) -> None:
+        # If even one tire pressure carries a real reading the incoming
+        # unit is considered trustworthy and replaces the previous.
+        previous = VehicleRealtimeData.model_validate(
+            {
+                "tirePressUnit": int(TirePressureUnit.PSI),
+                "leftFrontTirepressure": 38.4,
+            }
+        )
+        incoming = VehicleRealtimeData.model_validate(
+            {
+                "tirePressUnit": int(TirePressureUnit.KPA),
+                "leftFrontTirepressure": 260.0,
+                "rightFrontTirepressure": 0,
+                "leftRearTirepressure": 0,
+                "rightRearTirepressure": 0,
+            }
+        )
+
+        filtered = apply_realtime_filters(previous, incoming)
+
+        assert filtered.tire_press_unit == TirePressureUnit.KPA
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The HTTP /vehicleRealTimeResult endpoint returns the realtime block with `tirePressUnit: 3` (kPa, the default) and every tire pressure set to `0` even on vehicles configured for PSI. The existing zero-drop filters preserve the previous numeric pressure values, but `tirePressUnit` had no such guard, so the unit flipped PSI → kPa while the numeric pressures kept their PSI-scale last-known values.

Any consumer doing display-unit conversion (e.g. HA's sensor platform when the user picks PSI display) then divided the preserved values by 6.89476 until the next MQTT push restored the real unit — producing phantom drops of ~30 PSI lasting 1–11 minutes per HTTP poll, observed 14 times in 7 days on one vehicle.

Add a cross-field guard in apply_realtime_filters that drops the incoming `tire_press_unit` (preserving the previous) whenever all four pressures on the incoming payload read 0 / None. Partial-data payloads (at least one tire reporting) still accept the incoming unit, so a real unit change on the vehicle is not blocked.

Tests cover the four cases: all-zero pressures preserve previous unit, non-zero pressures accept incoming unit, partial pressures accept incoming unit, first-poll all-zero drops the unit (matches the rest of the zero-drop family).