### PR TITLE
preserve oil_percent when HTTP placeholder zeroes it

### DIFF
--- a/src/pybyd/_validators.py
+++ b/src/pybyd/_validators.py
@@ -69,6 +69,7 @@ _ZERO_DROP_FIELD_NAMES: tuple[str, ...] = (
     "total_mileage",
     "total_mileage_v2",
     "oil_endurance",
+    "oil_percent",
 )
 
 # Energy consumption fields where the HTTP /getEnergyConsumption endpoint

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -184,6 +184,7 @@ class TestApplyRealtimeZeroDropGating:
             ("total_mileage", 18234.0),
             ("total_mileage_v2", 18234.0),
             ("oil_endurance", 420.0),
+            ("oil_percent", 74.0),
         ],
     )
     def test_zero_incoming_with_previous_keeps_previous(self, field_name: str, previous_value: float) -> None:
@@ -208,6 +209,7 @@ class TestApplyRealtimeZeroDropGating:
             "total_mileage",
             "total_mileage_v2",
             "oil_endurance",
+            "oil_percent",
         ],
     )
     def test_zero_incoming_without_previous_dropped(self, field_name: str) -> None:
@@ -231,6 +233,7 @@ class TestApplyRealtimeZeroDropGating:
             ("total_mileage", 18234.0, 18240.0),
             ("total_mileage_v2", 18234.0, 18240.0),
             ("oil_endurance", 420.0, 410.0),
+            ("oil_percent", 74.0, 72.0),
         ],
     )
     def test_nonzero_incoming_replaces_previous(


### PR DESCRIPTION
Same family as the tire-pressure-unit drop: HTTP /vehicleRealTimeResult sometimes returns the realtime block with placeholder zeroes (all four tire pressures = 0, tempInCar = 0, oilPercent = 0) while is_ready_raw still accepts the payload because other fields (enduranceMileage, time, etc.) carry real values.

Without a zero-drop guard the placeholder `oilPercent: 0` clobbers the last-known good MQTT value, so the fuel_level sensor in HA drops to 0% for a poll cycle until the next MQTT push restores the real reading.

Add `oil_percent` to _ZERO_DROP_FIELD_NAMES alongside the existing oil_endurance / SOC / tire-pressure / odometer entries, and extend the three parametrized tests in TestApplyRealtimeZeroDropGating to cover the new field.