### PR TITLE
add HVAC filter pipeline + placeholder guard + temp_out_car sentinel

### DIFF
--- a/src/pybyd/_state_engine.py
+++ b/src/pybyd/_state_engine.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from dataclasses import field as dc_field
 from typing import Any
 
-from pybyd._validators import apply_gps_filters, apply_realtime_filters
+from pybyd._validators import apply_gps_filters, apply_hvac_filters, apply_realtime_filters
 from pybyd.models.charging import ChargingStatus
 from pybyd.models.energy import EnergyConsumption
 from pybyd.models.gps import GpsInfo
@@ -228,10 +228,11 @@ class VehicleStateEngine:
             self._rebuild_snapshot()
 
     async def update_hvac(self, data: HvacStatus) -> None:
-        """Merge incoming HVAC data through the guard window."""
+        """Merge incoming HVAC data through centralized filters and guard window."""
         async with self._lock:
-            self._base_hvac = data
-            self._reconcile_projections("hvac", data)
+            validated = apply_hvac_filters(self._base_hvac, data)
+            self._base_hvac = validated
+            self._reconcile_projections("hvac", validated)
             self._rebuild_snapshot()
 
     async def update_gps(self, data: GpsInfo) -> None:

--- a/src/pybyd/_validators.py
+++ b/src/pybyd/_validators.py
@@ -47,6 +47,7 @@ from collections.abc import Callable
 from typing import Any
 
 from pybyd.models.gps import GpsInfo
+from pybyd.models.hvac import HvacStatus
 from pybyd.models.realtime import VehicleRealtimeData
 
 _GPS_NULL_ISLAND_THRESHOLD: float = 0.1
@@ -69,6 +70,18 @@ _ZERO_DROP_FIELD_NAMES: tuple[str, ...] = (
     "total_mileage",
     "total_mileage_v2",
     "oil_endurance",
+)
+
+# HVAC sensor-population fields the cloud uses together to signal a
+# placeholder payload: when every reading is the "no data" value the
+# payload carries no real sensor data, only state and setpoints. Used by
+# :func:`_is_hvac_placeholder` to detect the bad payload as a whole
+# rather than guarding each field individually — a real 0 °C reading or
+# real 0 µg/m³ PM measurement must round-trip cleanly.
+_HVAC_SENSOR_FIELDS: tuple[str, ...] = (
+    "temp_in_car",
+    "temp_out_car",
+    "pm",
 )
 
 # Energy consumption fields where the HTTP /getEnergyConsumption endpoint
@@ -215,6 +228,55 @@ def apply_realtime_filters(
     """
     baseline = previous if previous is not None else VehicleRealtimeData.model_validate({})
     updates = _apply_model_field_filters(baseline, incoming, _REALTIME_FIELD_FILTERS)
+    if updates:
+        return incoming.model_copy(update=updates)
+    return incoming
+
+
+def _is_hvac_placeholder(data: HvacStatus) -> bool:
+    """Return True when *data* carries no real sensor readings.
+
+    The HTTP /control/getStatusNow endpoint occasionally returns a
+    payload where every sensor-populated field (cabin temperature,
+    exterior temperature, PM2.5) is zero or absent, while state and
+    setpoint fields keep their last values. Treat such payloads as
+    placeholders and skip the sensor-field merge so the previous MQTT
+    readings survive until the next push.
+
+    Any one sensor reporting a real value flips the verdict — a payload
+    with ``pm: 0, temp_in_car: 22, temp_out_car: 0`` is accepted as a
+    legitimate cold-start reading where exterior happens to read 0 °C.
+    """
+    return all(
+        getattr(data, f, None) in (None, 0, 0.0) for f in _HVAC_SENSOR_FIELDS
+    )
+
+
+def apply_hvac_filters(
+    previous: HvacStatus | None,
+    incoming: HvacStatus,
+) -> HvacStatus:
+    """Apply HVAC filtering rules.
+
+    Drops the sensor-population fields (``temp_in_car``, ``temp_out_car``,
+    ``pm``) when *incoming* matches the placeholder signature — every
+    sensor field reads zero or is absent. Setpoints, state enums, and
+    other fields on the payload still flow through unchanged; only the
+    sensor readings are pinned to the previous values.
+
+    Temperature fields additionally use BYD's documented ``-129``
+    sentinel via :func:`is_temp_sentinel` on the model itself, so a real
+    0 °C reading on a non-placeholder payload round-trips unchanged.
+    """
+    if previous is None:
+        return incoming
+    if not _is_hvac_placeholder(incoming):
+        return incoming
+    updates: dict[str, Any] = {}
+    for field_name in _HVAC_SENSOR_FIELDS:
+        prev_value = getattr(previous, field_name, None)
+        if prev_value is not None:
+            updates[field_name] = prev_value
     if updates:
         return incoming.model_copy(update=updates)
     return incoming

--- a/src/pybyd/models/hvac.py
+++ b/src/pybyd/models/hvac.py
@@ -80,6 +80,7 @@ class HvacStatus(BydBaseModel):
 
     _SENTINEL_RULES: ClassVar[dict[str, Callable[..., bool]]] = {
         "temp_in_car": is_temp_sentinel,
+        "temp_out_car": is_temp_sentinel,
     }
 
     # --- A/C state ---
@@ -108,7 +109,7 @@ class HvacStatus(BydBaseModel):
     temp_in_car: float | None = None
     """Interior temperature (deg C). Sentinel ``-129`` -> ``None``."""
     temp_out_car: float | None = None
-    """Exterior temperature (deg C)."""
+    """Exterior temperature (deg C). Sentinel ``-129`` -> ``None``."""
     whether_support_adjust_temp: int | None = None
     """1 = dual-zone temperature adjustment supported."""
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,10 +7,12 @@ import pytest
 from pybyd._validators import (
     _has_valid_coordinates,
     apply_gps_filters,
+    apply_hvac_filters,
     apply_realtime_filters,
     guard_gps_coordinates,
 )
 from pybyd.models.gps import GpsInfo
+from pybyd.models.hvac import HvacStatus
 from pybyd.models.realtime import LockState, VehicleRealtimeData
 from pybyd.models.vehicle import EnergyType
 
@@ -383,6 +385,89 @@ class TestApplyRealtimePreserveWhenNone:
         filtered = apply_realtime_filters(previous, incoming)
 
         assert getattr(filtered, field_name) == incoming_value
+
+
+# ---------------------------------------------------------------------------
+# apply_hvac_filters – zero-drop gating for HVAC temperature / air quality
+# ---------------------------------------------------------------------------
+
+
+class TestApplyHvacPlaceholderGuard:
+    """Cross-field placeholder detection for HVAC payloads.
+
+    A payload where every sensor-population field reads ``0`` or is
+    absent is treated as a placeholder: the sensor fields are pinned to
+    the previous values while setpoints / state enums still flow
+    through. Any one sensor reporting a real value flips the verdict so
+    a genuine 0 °C reading (or 0 µg/m³ PM reading) round-trips intact.
+    """
+
+    def test_all_sensor_zeros_keeps_previous(self) -> None:
+        previous = HvacStatus.model_validate(
+            {"tempInCar": 22.0, "tempOutCar": 18.0, "pm": 12.0}
+        )
+        incoming = HvacStatus.model_validate(
+            {"tempInCar": 0, "tempOutCar": 0, "pm": 0, "mainSettingTemp": 24}
+        )
+
+        filtered = apply_hvac_filters(previous, incoming)
+
+        assert filtered.temp_in_car == 22.0
+        assert filtered.temp_out_car == 18.0
+        assert filtered.pm == 12.0
+        # Non-sensor fields still update from incoming.
+        assert filtered.main_setting_temp == 24.0
+
+    def test_real_cabin_temperature_lets_payload_through(self) -> None:
+        """One real sensor reading proves the payload isn't placeholder."""
+        previous = HvacStatus.model_validate(
+            {"tempInCar": 22.0, "tempOutCar": 18.0, "pm": 12.0}
+        )
+        incoming = HvacStatus.model_validate(
+            {"tempInCar": 23.0, "tempOutCar": 0, "pm": 0}
+        )
+
+        filtered = apply_hvac_filters(previous, incoming)
+
+        # Incoming temp_in_car update accepted; the other two real-but-zero
+        # readings (cold-snap exterior, clean air) flow through too.
+        assert filtered.temp_in_car == 23.0
+        assert filtered.temp_out_car == 0.0
+        assert filtered.pm == 0.0
+
+    def test_genuine_zero_exterior_temperature_passes_through(self) -> None:
+        previous = HvacStatus.model_validate(
+            {"tempInCar": 22.0, "tempOutCar": 5.0, "pm": 12.0}
+        )
+        incoming = HvacStatus.model_validate(
+            {"tempInCar": 21.0, "tempOutCar": 0, "pm": 11.0}
+        )
+
+        filtered = apply_hvac_filters(previous, incoming)
+
+        assert filtered.temp_out_car == 0.0
+
+    def test_placeholder_without_previous_passes_through(self) -> None:
+        """First poll: no previous values to preserve, accept incoming as-is."""
+        incoming = HvacStatus.model_validate(
+            {"tempInCar": 0, "tempOutCar": 0, "pm": 0}
+        )
+
+        filtered = apply_hvac_filters(None, incoming)
+
+        # The model itself applies no sentinel rule for ``0`` on temperature
+        # fields, so the values pass through. Subsequent placeholder
+        # payloads will be guarded once a real reading establishes baseline.
+        assert filtered.temp_in_car == 0.0
+        assert filtered.temp_out_car == 0.0
+        assert filtered.pm == 0.0
+
+    @pytest.mark.parametrize("field_name", ["temp_in_car", "temp_out_car"])
+    def test_sentinel_temperature_maps_to_none(self, field_name: str) -> None:
+        """BYD's documented -129 sentinel maps to None on the model itself."""
+        m = HvacStatus.model_validate({field_name: -129})
+
+        assert getattr(m, field_name) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The HvacStatus section had no validator wiring at all — incoming payloads were merged into the snapshot as-is. That left two related symptoms in the user's HA history:

  - climate.current_temperature occasionally read 0 °C
  - sensor.<vin>_exterior_temperature occasionally read 0 °C

Both fire at HTTP poll cadence on a different timeline than the realtime-section drops (cabin temp + tire pressure), pointing at the HVAC HTTP endpoint. The recorded values are literal 0, not -129, so a sentinel-only fix isn't enough on its own.

This commit:

  1. Adds apply_hvac_filters() symmetric with apply_realtime_filters() and wires it into VehicleStateEngine.update_hvac.
  2. Detects the placeholder cross-field rather than per-field — when every sensor-population field (temp_in_car, temp_out_car, pm) on the incoming payload reads 0 or is absent, those three fields are pinned to the previous values. Setpoints / state enums on the same payload still update. This avoids the false-positive of dropping a genuine 0 °C reading on a payload that also carries a real temp_in_car or pm value.
  3. Adds temp_out_car: is_temp_sentinel to HvacStatus so the documented -129 sentinel maps to None, matching the existing temp_in_car rule. Defensive cleanup — orthogonal to the placeholder issue, but related.

A truly cold 0 °C exterior reading round-trips intact as long as the same payload carries any other real sensor value (which it always does in practice, since real payloads include the cabin temperature). First poll with all-zero sensors passes through unchanged because there's no previous baseline to preserve — subsequent placeholder payloads will be guarded once a real reading establishes one.