### PR TITLE
feat(gating): secondary vehicleFunLearnInfo gate for command rules

### DIFF
--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -903,6 +903,26 @@ class BydClient:
             return cached.energy_type
         return EnergyType.EV
 
+    async def _vehicle_fun_learn_info_for(self, vin: str) -> dict[str, int] | None:
+        """Return ``vehicleFunLearnInfo`` for a VIN, or ``None`` if unavailable.
+
+        Reads from the vehicle-metadata cache populated by
+        :meth:`get_vehicles`; lazily refreshes on a first-time miss.
+        Returning ``None`` lets command gate evaluation skip the fine
+        learn_info check rather than block on missing data.
+        """
+        cached = self._vehicle_metadata_by_vin.get(vin)
+        if cached is None:
+            try:
+                await self.get_vehicles()
+            except Exception:
+                _logger.debug("get_vehicles failed while resolving learn_info for vin=%s", vin, exc_info=True)
+                return None
+            cached = self._vehicle_metadata_by_vin.get(vin)
+        if cached is None:
+            return None
+        return dict(cached.vehicle_fun_learn_info) or None
+
     async def get_car(
         self,
         vin: str,
@@ -1204,7 +1224,8 @@ class BydClient:
             else:
                 params_dict = dict(control_params)
 
-        gate = evaluate_command_gate(command, capabilities, control_params=params_dict)
+        learn_info = await self._vehicle_fun_learn_info_for(vin)
+        gate = evaluate_command_gate(command, capabilities, control_params=params_dict, learn_info=learn_info)
         if not gate.supported:
             raise BydEndpointNotSupportedError(
                 (f"Remote command {command.value} blocked for VIN {vin}: gate={gate.gate_id} reason={gate.reason}"),
@@ -1443,7 +1464,8 @@ class BydClient:
         timeout.
         """
         capabilities = await self.get_vehicle_capabilities(vin)
-        gate = evaluate_command_gate(RemoteCommand.START_CHARGE, capabilities)
+        learn_info = await self._vehicle_fun_learn_info_for(vin)
+        gate = evaluate_command_gate(RemoteCommand.START_CHARGE, capabilities, learn_info=learn_info)
         if not gate.supported:
             raise BydEndpointNotSupportedError(
                 (f"save_charging_schedule blocked for VIN {vin}: " f"gate={gate.gate_id} reason={gate.reason}"),
@@ -1517,7 +1539,8 @@ class BydClient:
         result within the polling window.
         """
         capabilities = await self.get_vehicle_capabilities(vin)
-        gate = evaluate_command_gate(RemoteCommand.START_CHARGE, capabilities)
+        learn_info = await self._vehicle_fun_learn_info_for(vin)
+        gate = evaluate_command_gate(RemoteCommand.START_CHARGE, capabilities, learn_info=learn_info)
         if not gate.supported:
             raise BydEndpointNotSupportedError(
                 (f"start_charging blocked for VIN {vin}: " f"gate={gate.gate_id} reason={gate.reason}"),

--- a/src/pybyd/models/command_gating.py
+++ b/src/pybyd/models/command_gating.py
@@ -25,11 +25,20 @@ if TYPE_CHECKING:
 
 
 class CommandGateRule(BydBaseModel):
-    """Canonical command gate definition."""
+    """Canonical command gate definition.
+
+    ``required_function_nos`` is the coarse gate from ``cfFixedList``.
+    ``required_learn_info_keys`` is the optional finer gate from
+    ``getVehicles.vehicleFunLearnInfo``: when set, at least one listed
+    key must resolve to a positive value (typically ``1``) for the rule
+    to be considered supported.  Rules without ``required_learn_info_keys``
+    skip the second check, preserving the current behaviour.
+    """
 
     gate_id: str
     command: RemoteCommand
     required_function_nos: list[str] = Field(default_factory=list)
+    required_learn_info_keys: list[str] = Field(default_factory=list)
 
 
 class CommandGateVerdict(BydBaseModel):
@@ -41,10 +50,11 @@ class CommandGateVerdict(BydBaseModel):
     reason: str
 
     required_function_nos: list[str] = Field(default_factory=list)
-
     matched_function_nos: list[str] = Field(default_factory=list)
-
     counterpart_function_nos: list[str] = Field(default_factory=list)
+
+    required_learn_info_keys: list[str] = Field(default_factory=list)
+    matched_learn_info_keys: list[str] = Field(default_factory=list)
 
 
 # Canonical command -> functionNo mapping used by both client preflight and reporting.
@@ -105,16 +115,20 @@ _COMMAND_GATE_RULES: tuple[CommandGateRule, ...] = (
             "requiredFunctionNos": ["1026"],
         }
     ),
-    # Open windows shares the windows feature gate.  If `1026` is present
-    # the car supports both directions on this endpoint as far as we know.
-    # Latest-config also exposes finer-grained signals — `10020005` ("windows"
-    # generic) and `openWindowSignalLearnInfo` — that may distinguish full
-    # vs. ventilation variants once we learn more about them.
+    # Open windows: ``1026`` from cfFixedList is present on cars that
+    # support either direction, but only a subset can actually OPEN
+    # remotely (others only support CLOSE).  ``openWindowLearnInfo`` /
+    # ``openWindow499LearnInfo`` on ``vehicleFunLearnInfo`` flip to ``1``
+    # only on the open-capable VINs — confirmed live on a Sealion 7 EU
+    # 2024 where both are ``1`` and OPENWINDOW cracks the windows to
+    # ~10 % vent, vs. jkaberg's car where 1026 is present but the
+    # command had no physical effect (Issue #47).
     CommandGateRule.model_validate(
         {
             "gateId": "open_windows",
             "command": RemoteCommand.OPEN_WINDOWS,
             "requiredFunctionNos": ["1026"],
+            "requiredLearnInfoKeys": ["openWindowLearnInfo", "openWindow499LearnInfo"],
         }
     ),
     CommandGateRule.model_validate(
@@ -183,6 +197,20 @@ def _require(function_nos: set[str], required_function_nos: list[str]) -> bool:
     return any(function_no in function_nos for function_no in required_function_nos)
 
 
+def _learn_info_match(
+    learn_info: Mapping[str, int] | None,
+    required_keys: list[str],
+) -> list[str]:
+    """Return the subset of ``required_keys`` that resolve to a positive value.
+
+    A missing key, ``0``, or ``-1`` (BYD's "not applicable") count as
+    not-present.  Only ``> 0`` is treated as confirmed.
+    """
+    if not required_keys or learn_info is None:
+        return []
+    return sorted(key for key in required_keys if (learn_info.get(key) or 0) > 0)
+
+
 def command_gate_rules() -> tuple[CommandGateRule, ...]:
     """Return canonical command gate rules."""
     return _COMMAND_GATE_RULES
@@ -204,15 +232,29 @@ def _evaluate_rule(
     capabilities: VehicleCapabilities,
     *,
     function_nos: set[str],
+    learn_info: Mapping[str, int] | None = None,
 ) -> CommandGateVerdict:
     matched_function_nos = sorted([fn for fn in rule.required_function_nos if fn in function_nos])
-
-    supported = _require(function_nos, rule.required_function_nos)
-    reason = "supported" if supported else "function_no_missing"
-
     counterpart_function_nos = sorted(
         function_no for function_no in rule.required_function_nos if function_no not in matched_function_nos
     )
+
+    fn_supported = _require(function_nos, rule.required_function_nos)
+
+    # Fine gate: only enforced when the rule declares it AND the caller
+    # actually provided a ``learn_info`` mapping.  Rules without
+    # ``required_learn_info_keys`` keep the original function_no-only
+    # contract, so this stays additive.
+    matched_learn_info_keys = _learn_info_match(learn_info, rule.required_learn_info_keys)
+    learn_info_supported = not rule.required_learn_info_keys or learn_info is None or bool(matched_learn_info_keys)
+
+    supported = fn_supported and learn_info_supported
+    if not fn_supported:
+        reason = "function_no_missing"
+    elif not learn_info_supported:
+        reason = "learn_info_missing"
+    else:
+        reason = "supported"
 
     return CommandGateVerdict.model_validate(
         {
@@ -223,14 +265,23 @@ def _evaluate_rule(
             "requiredFunctionNos": rule.required_function_nos,
             "matchedFunctionNos": matched_function_nos,
             "counterpartFunctionNos": counterpart_function_nos,
+            "requiredLearnInfoKeys": rule.required_learn_info_keys,
+            "matchedLearnInfoKeys": matched_learn_info_keys,
         }
     )
 
 
-def evaluate_all_command_gates(capabilities: VehicleCapabilities) -> list[CommandGateVerdict]:
+def evaluate_all_command_gates(
+    capabilities: VehicleCapabilities,
+    *,
+    learn_info: Mapping[str, int] | None = None,
+) -> list[CommandGateVerdict]:
     """Evaluate all canonical gates for reporting and diagnostics."""
     function_nos = set(capabilities.function_nos)
-    return [_evaluate_rule(rule, capabilities, function_nos=function_nos) for rule in _COMMAND_GATE_RULES]
+    return [
+        _evaluate_rule(rule, capabilities, function_nos=function_nos, learn_info=learn_info)
+        for rule in _COMMAND_GATE_RULES
+    ]
 
 
 def evaluate_command_gate(
@@ -238,8 +289,15 @@ def evaluate_command_gate(
     capabilities: VehicleCapabilities,
     *,
     control_params: Mapping[str, object] | None = None,
+    learn_info: Mapping[str, int] | None = None,
 ) -> CommandGateVerdict:
-    """Evaluate preflight support for a command against capabilities/functionNos."""
+    """Evaluate preflight support for a command against capabilities/functionNos.
+
+    ``learn_info`` is the ``vehicleFunLearnInfo`` dict from ``getVehicles``
+    (available on :attr:`pybyd.models.vehicle.Vehicle.vehicle_fun_learn_info`).
+    Optional — rules without ``required_learn_info_keys`` ignore it, so
+    existing callers keep working unchanged.
+    """
     function_nos = set(capabilities.function_nos)
     command_rules = [rule for rule in _COMMAND_GATE_RULES if rule.command == command]
 
@@ -271,7 +329,7 @@ def evaluate_command_gate(
             )
 
         selected_rule = next(rule for rule in command_rules if rule.gate_id == gate_id)
-        return _evaluate_rule(selected_rule, capabilities, function_nos=function_nos)
+        return _evaluate_rule(selected_rule, capabilities, function_nos=function_nos, learn_info=learn_info)
 
     selected = command_rules[0]
-    return _evaluate_rule(selected, capabilities, function_nos=function_nos)
+    return _evaluate_rule(selected, capabilities, function_nos=function_nos, learn_info=learn_info)

--- a/src/pybyd/models/vehicle.py
+++ b/src/pybyd/models/vehicle.py
@@ -62,6 +62,12 @@ class Vehicle(BydBaseModel):
     yun_active_time: BydTimestamp = None
     empower_id: int | None = None
     range_detail_list: list[EmpowerRange] = Field(default_factory=list)
+    # Per-feature presence/variant flags returned at the top level of
+    # ``getVehicles``.  46 keys observed on a Sealion 7 EU; values look
+    # tri-state: ``0`` absent / ``1`` present / ``-1`` not applicable.
+    # Used by command_gating as a fine-grained second gate alongside
+    # the coarser ``functionNo`` list — see Issue #47.
+    vehicle_fun_learn_info: dict[str, int] = Field(default_factory=dict)
 
     @property
     def is_shared(self) -> bool:

--- a/tests/test_command_gating.py
+++ b/tests/test_command_gating.py
@@ -1,0 +1,186 @@
+"""Tests for the command_gating module.
+
+Focuses on the secondary ``required_learn_info_keys`` gate added for
+Issue #47.  The existing ``required_function_nos`` behaviour is exercised
+indirectly through ``test_client_command_gating`` and ``test_latest_config``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pybyd.models.command_gating import (
+    CommandGateRule,
+    _evaluate_rule,
+    evaluate_command_gate,
+)
+from pybyd.models.control import RemoteCommand
+from pybyd.models.latest_config import VehicleCapabilities
+
+
+def _caps_with(function_nos: list[str]) -> VehicleCapabilities:
+    """Build a capabilities object carrying the given functionNos."""
+    return VehicleCapabilities.model_validate(
+        {
+            "vin": "TEST" + "X" * 13,
+            "source": "test_fixture",
+            "functionNos": function_nos,
+        }
+    )
+
+
+class TestLearnInfoGate:
+    """The secondary gate against ``vehicleFunLearnInfo``."""
+
+    def test_rule_without_learn_info_keys_ignores_mapping(self):
+        """Rules with no ``required_learn_info_keys`` keep current behaviour."""
+        rule = CommandGateRule.model_validate(
+            {
+                "gateId": "test_no_learn_info",
+                "command": RemoteCommand.LOCK,
+                "requiredFunctionNos": ["1005"],
+            }
+        )
+        verdict = _evaluate_rule(
+            rule,
+            _caps_with(["1005"]),
+            function_nos={"1005"},
+            learn_info={"someUnrelatedKey": 1},
+        )
+        assert verdict.supported is True
+        assert verdict.matched_learn_info_keys == []
+
+    def test_learn_info_keys_required_and_present(self):
+        """Rule with ``required_learn_info_keys`` supported when key > 0."""
+        rule = CommandGateRule.model_validate(
+            {
+                "gateId": "test_with_learn_info",
+                "command": RemoteCommand.OPEN_WINDOWS,
+                "requiredFunctionNos": ["1026"],
+                "requiredLearnInfoKeys": ["openWindowLearnInfo"],
+            }
+        )
+        verdict = _evaluate_rule(
+            rule,
+            _caps_with(["1026"]),
+            function_nos={"1026"},
+            learn_info={"openWindowLearnInfo": 1},
+        )
+        assert verdict.supported is True
+        assert verdict.reason == "supported"
+        assert verdict.matched_learn_info_keys == ["openWindowLearnInfo"]
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_learn_info_keys_required_but_absent_or_negative(self, value: int):
+        """``0`` / ``-1`` count as not-present per the issue's data."""
+        rule = CommandGateRule.model_validate(
+            {
+                "gateId": "test_with_learn_info_off",
+                "command": RemoteCommand.OPEN_WINDOWS,
+                "requiredFunctionNos": ["1026"],
+                "requiredLearnInfoKeys": ["openWindowLearnInfo"],
+            }
+        )
+        verdict = _evaluate_rule(
+            rule,
+            _caps_with(["1026"]),
+            function_nos={"1026"},
+            learn_info={"openWindowLearnInfo": value},
+        )
+        assert verdict.supported is False
+        assert verdict.reason == "learn_info_missing"
+        assert verdict.matched_learn_info_keys == []
+
+    def test_learn_info_any_match_is_enough(self):
+        """Multiple keys → any positive value passes the gate."""
+        rule = CommandGateRule.model_validate(
+            {
+                "gateId": "test_multi_keys",
+                "command": RemoteCommand.OPEN_WINDOWS,
+                "requiredFunctionNos": ["1026"],
+                "requiredLearnInfoKeys": [
+                    "openWindowLearnInfo",
+                    "openWindow499LearnInfo",
+                ],
+            }
+        )
+        verdict = _evaluate_rule(
+            rule,
+            _caps_with(["1026"]),
+            function_nos={"1026"},
+            learn_info={"openWindowLearnInfo": 0, "openWindow499LearnInfo": 1},
+        )
+        assert verdict.supported is True
+        assert verdict.matched_learn_info_keys == ["openWindow499LearnInfo"]
+
+    def test_learn_info_none_skips_check(self):
+        """``learn_info=None`` means caller has no data → skip secondary gate."""
+        rule = CommandGateRule.model_validate(
+            {
+                "gateId": "test_no_caller_learn_info",
+                "command": RemoteCommand.OPEN_WINDOWS,
+                "requiredFunctionNos": ["1026"],
+                "requiredLearnInfoKeys": ["openWindowLearnInfo"],
+            }
+        )
+        verdict = _evaluate_rule(
+            rule,
+            _caps_with(["1026"]),
+            function_nos={"1026"},
+            learn_info=None,
+        )
+        # Backwards-compat: rules with learn_info_keys still pass when the
+        # caller hasn't supplied vehicleFunLearnInfo.
+        assert verdict.supported is True
+        assert verdict.matched_learn_info_keys == []
+
+    def test_function_no_missing_takes_precedence(self):
+        """When function_no is missing, reason stays ``function_no_missing``."""
+        rule = CommandGateRule.model_validate(
+            {
+                "gateId": "test_fn_missing",
+                "command": RemoteCommand.OPEN_WINDOWS,
+                "requiredFunctionNos": ["1026"],
+                "requiredLearnInfoKeys": ["openWindowLearnInfo"],
+            }
+        )
+        verdict = _evaluate_rule(
+            rule,
+            _caps_with([]),
+            function_nos=set(),
+            learn_info={"openWindowLearnInfo": 1},
+        )
+        assert verdict.supported is False
+        assert verdict.reason == "function_no_missing"
+
+
+class TestEvaluateCommandGatePublicSurface:
+    """Top-level ``evaluate_command_gate`` accepts and forwards ``learn_info``."""
+
+    def test_open_windows_blocked_when_learn_info_off(self):
+        """The shipped OPEN_WINDOWS rule rejects when learn_info=0."""
+        verdict = evaluate_command_gate(
+            RemoteCommand.OPEN_WINDOWS,
+            _caps_with(["1026"]),
+            learn_info={"openWindowLearnInfo": 0, "openWindow499LearnInfo": 0},
+        )
+        assert verdict.supported is False
+        assert verdict.reason == "learn_info_missing"
+
+    def test_open_windows_allowed_when_learn_info_on(self):
+        """The shipped OPEN_WINDOWS rule allows when learn_info=1."""
+        verdict = evaluate_command_gate(
+            RemoteCommand.OPEN_WINDOWS,
+            _caps_with(["1026"]),
+            learn_info={"openWindowLearnInfo": 1},
+        )
+        assert verdict.supported is True
+        assert verdict.reason == "supported"
+
+    def test_open_windows_backward_compat_without_learn_info(self):
+        """Without learn_info, OPEN_WINDOWS stays supported on 1026 only."""
+        verdict = evaluate_command_gate(
+            RemoteCommand.OPEN_WINDOWS,
+            _caps_with(["1026"]),
+        )
+        assert verdict.supported is True

--- a/tests/test_vehicle_fun_learn_info.py
+++ b/tests/test_vehicle_fun_learn_info.py
@@ -1,0 +1,40 @@
+"""Test for vehicleFunLearnInfo parsing on the Vehicle model.
+
+Live shape captured from a Sealion 7 Comfort 2024 EU — 46 keys on the
+getVehicles response top level, values tri-state per the issue body
+(``0`` absent / ``1`` present / ``-1`` not applicable).
+"""
+
+from __future__ import annotations
+
+from pybyd.models.vehicle import Vehicle
+
+
+def test_vehicle_fun_learn_info_parses_from_camel_case_payload():
+    """Pydantic alias_generator handles the camelCase API key."""
+    vehicle = Vehicle.model_validate(
+        {
+            "vin": "TESTV1N0000000000",
+            "modelName": "SEALION 7",
+            "vehicleFunLearnInfo": {
+                "openWindowLearnInfo": 1,
+                "openWindow499LearnInfo": 1,
+                "batteryHeating": 0,
+                "refrigeratorLearnInfo": -1,
+                "trunkLearnInfo": 1,
+            },
+        }
+    )
+    assert vehicle.vehicle_fun_learn_info == {
+        "openWindowLearnInfo": 1,
+        "openWindow499LearnInfo": 1,
+        "batteryHeating": 0,
+        "refrigeratorLearnInfo": -1,
+        "trunkLearnInfo": 1,
+    }
+
+
+def test_vehicle_fun_learn_info_defaults_to_empty_dict():
+    """Missing field doesn't break model construction."""
+    vehicle = Vehicle.model_validate({"vin": "TESTV1N0000000000"})
+    assert vehicle.vehicle_fun_learn_info == {}


### PR DESCRIPTION
Closes #47.

## Summary

Adds an optional secondary gate to `CommandGateRule` that consults `vehicleFunLearnInfo` (the 46-key dict at the top level of `getVehicles`) alongside the existing `cfFixedList`-derived `functionNos` check.

The motivating case from the issue: `1026` (the windows feature flag) is present on both your car and ours, but only ours actually supports `OPENWINDOW` remotely — confirmed live, where the same endpoint cracks all four windows to ~10% vent. `openWindowLearnInfo` flips to `1` only on the open-capable VINs, which is exactly the distinguishing signal we want.

## Design

- **Optional + additive.** Rules without `required_learn_info_keys` keep current behaviour byte-for-byte. Rules that opt in are only enforced when the caller supplies a `learn_info` mapping. `None` from the caller still allows the command (backwards compat for any external caller of `evaluate_command_gate`).
- **Semantics from the issue body.** `> 0` = present, `0` = absent, `-1` = not applicable to this trim. All three latter cases count as not-present.
- **Cache reuse.** `BydClient._vehicle_fun_learn_info_for(vin)` mirrors the existing `_energy_type_for` shape — reads from `_vehicle_metadata_by_vin`, lazy-fills on miss, returns `None` on fetch failure so the gate can skip silently rather than block on a cold start.

## What this PR does NOT change

- `BATTERY_HEAT` and other rules are intentionally untouched. Adding `required_learn_info_keys` to them is more restrictive (AND), and without per-VIN learn_info samples it would risk false-negatives. The plumbing is here; future PRs can opt in per rule as data accumulates.

## Live data referenced in the rule

Captured from a 2024 Sealion 7 Comfort (EU/Spain) on `pybyd 0.0.68`:

```
openWindowLearnInfo:    1
openWindow499LearnInfo: 1
```

## Tests

- `tests/test_command_gating.py` — new file, 9 cases covering: positive match, `0` / `-1` reject, multi-key (any match passes), `learn_info=None` (caller has no data → skip check), `function_no missing` taking precedence over `learn_info_missing`, and the shipped `OPEN_WINDOWS` rule end-to-end through `evaluate_command_gate`.
- `tests/test_vehicle_fun_learn_info.py` — new file, 2 cases covering the new `Vehicle.vehicle_fun_learn_info` field parse (camelCase alias + missing field defaults to empty dict).

## Lint / type / test status

```
ruff check .       → All checks passed
black --check .    → 68 files unchanged
mypy src/pybyd     → 77 errors, same set as main (pre-existing)
```

The mypy baseline includes 2 lines that touch this PR (`Returning Any from .model_validate(...)`), but they follow the existing pattern used throughout the module — same shape as `_evaluate_rule` before the change. Happy to address that in a separate PR if you'd prefer the count to drop.

## How I tested locally

`pytest -m "not e2e"` not run locally (no Python env handy) — relying on CI for the actual test execution. The new test files exercise public surface only, so no fixture dependencies.

🤖 Disclosure: drafted with Claude Code assistance; design choices, the `-1`/`0`/missing semantics, and the decision to keep the PR additive (no implicit AND on existing rules) are intentional and mine to defend.