### PR TITLE
fix(hvac): coerce enum fields (drop '| int' from union)

### DIFF
--- a/src/pybyd/models/hvac.py
+++ b/src/pybyd/models/hvac.py
@@ -84,17 +84,17 @@ class HvacStatus(BydBaseModel):
     }
 
     # --- A/C state ---
-    ac_switch: AcSwitch | int | None = None
+    ac_switch: AcSwitch | None = None
     """A/C switch state."""
-    status: HvacOverallStatus | int | None = None
+    status: HvacOverallStatus | None = None
     """Overall HVAC status."""
-    air_conditioning_mode: AirConditioningMode | int | None = None
+    air_conditioning_mode: AirConditioningMode | None = None
     """A/C mode (auto / manual)."""
-    wind_mode: HvacWindMode | int | None = None
+    wind_mode: HvacWindMode | None = None
     """Fan mode / airflow direction."""
-    wind_position: HvacWindPosition | int | None = None
+    wind_position: HvacWindPosition | None = None
     """Fan speed / airflow position."""
-    cycle_choice: AirCirculationMode | int | None = None
+    cycle_choice: AirCirculationMode | None = None
     """Air circulation mode (external / internal)."""
 
     # --- Temperature ---


### PR DESCRIPTION
Surfaced while working on the API mapping collaboration (#20).

## Problem
The six HVAC enum fields are typed `Enum | int | None`:
```
ac_switch, status, air_conditioning_mode, wind_mode, wind_position, cycle_choice
```
With pydantic's smart union, an integer payload value matches the **`int`** branch and is kept as a plain `int`, so the enum is **never resolved**. `getattr(value, "name", None)` returns `None` and enum comparisons silently fail — e.g. `air_conditioning_mode`/`wind_mode`/`wind_position` come back as bare ints, and HA sensors reading `.name` show `unknown` even when the value is present.

Every **other** enum field in pyBYD (realtime `power_gear`, `charge_state`, window/door/lock states, `air_run_state`, …) is typed `Enum | None` and coerces correctly. The HVAC fields are the lone inconsistency.

## Fix
Drop `| int` from the six HVAC enum fields so they match the rest of the codebase and coerce to their enums.

## Safety
- `BydEnum._missing_` maps unmapped integers to `UNKNOWN`, so unexpected values don't raise and no data is lost.
- `BydEnum` is an `IntEnum`, so any numeric comparison still works.
- Verified: `HvacStatus.model_validate({"airConditioningMode":1,...})` now yields `AirConditioningMode.AUTO` (was `int 1`). Full suite green (`159 passed`), ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
