### PR TITLE
feat(mqtt): on_connected callback (cloud-online signal)

### DIFF
--- a/src/pybyd/_mqtt.py
+++ b/src/pybyd/_mqtt.py
@@ -147,6 +147,7 @@ class BydMqttRuntime:
         decrypt_key_hex: str,
         on_event: Callable[[MqttEvent], None],
         on_decrypt_error: Callable[[], None] | None = None,
+        on_connected: Callable[[], None] | None = None,
         keepalive: int = 120,
         logger: logging.Logger | None = None,
     ) -> None:
@@ -154,6 +155,7 @@ class BydMqttRuntime:
         self._decrypt_key_hex = decrypt_key_hex
         self._on_event = on_event
         self._on_decrypt_error = on_decrypt_error
+        self._on_connected = on_connected
         self._keepalive = keepalive
         self._logger = logger or logging.getLogger(__name__)
         self._client: mqtt.Client | None = None
@@ -205,6 +207,10 @@ class BydMqttRuntime:
             if self._topic:
                 self._logger.debug("MQTT subscribe topic=%s", self._topic)
                 c.subscribe(self._topic, qos=0)
+            # Notify (on the asyncio loop) that the push channel is up —
+            # fires on first connect and on every paho auto-reconnect.
+            if self._on_connected is not None:
+                self._loop.call_soon_threadsafe(self._on_connected)
 
         def on_message(_c: mqtt.Client, _userdata: Any, msg: mqtt.MQTTMessage) -> None:
             try:

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -128,6 +128,7 @@ class BydClient:
         on_mqtt_event: Callable[[str, str, dict[str, Any]], None] | None = None,
         on_command_ack: Callable[[CommandAckEvent], None] | None = None,
         on_command_lifecycle: Callable[[CommandLifecycleEvent], None] | None = None,
+        on_mqtt_connect: Callable[[], None] | None = None,
         command_ack_ttl_seconds: float = 300.0,
     ) -> None:
         self._config = config
@@ -144,6 +145,7 @@ class BydClient:
         self._on_mqtt_event_cb = on_mqtt_event
         self._on_command_ack_cb = on_command_ack
         self._on_command_lifecycle_cb = on_command_lifecycle
+        self._on_mqtt_connect_cb = on_mqtt_connect
         self._command_ack_ttl_seconds = command_ack_ttl_seconds if command_ack_ttl_seconds > 0 else 300.0
         self._pending_commands: dict[tuple[str, str], _PendingCommand] = {}
         self._pending_matched_count = 0
@@ -442,6 +444,7 @@ class BydClient:
                 decrypt_key_hex=session.content_key(),
                 on_event=self._on_mqtt_event,
                 on_decrypt_error=self._schedule_mqtt_reauth,
+                on_connected=self._on_mqtt_connect_cb,
                 keepalive=self._config.mqtt_keepalive,
                 logger=_logger,
             )


### PR DESCRIPTION
## What
Add an optional `on_connected` callback to `BydMqttRuntime`, exposed as `BydClient(on_mqtt_connect=...)`. It fires (marshalled onto the asyncio loop via `call_soon_threadsafe`) whenever the MQTT push channel connects — on first connect **and on every paho auto-reconnect**.

## Why
Today the MQTT `on_connect`/`on_disconnect` handlers only log internally; there's no way for a consumer to know the push channel (re)connected. After a BYD cloud outage/maintenance window the broker comes back and paho auto-reconnects, but the integration can't surface a "cloud back up" signal. This callback provides exactly that — event-driven, no polling.

## Notes
- Fully backward compatible: `on_connected` defaults to `None`; existing callers are unaffected.
- Fires after the topic re-subscribe, so by the time it runs the channel is ready to receive.
- Verified: ruff/black/mypy clean, full suite green (`159 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
