### PR TITLE
Add Electric A/C functionNo 1015 climate support

### DIFF
--- a/src/pybyd/models/command_gating.py
+++ b/src/pybyd/models/command_gating.py
@@ -77,21 +77,21 @@ _COMMAND_GATE_RULES: tuple[CommandGateRule, ...] = (
         {
             "gateId": "climate",
             "command": RemoteCommand.START_CLIMATE,
-            "requiredFunctionNos": ["1001", "10300001"],
+            "requiredFunctionNos": ["1001", "10300001", "1015"],
         }
     ),
     CommandGateRule.model_validate(
         {
             "gateId": "climate",
             "command": RemoteCommand.STOP_CLIMATE,
-            "requiredFunctionNos": ["1001", "10300001"],
+            "requiredFunctionNos": ["1001", "10300001", "1015"],
         }
     ),
     CommandGateRule.model_validate(
         {
             "gateId": "climate_schedule",
             "command": RemoteCommand.SCHEDULE_CLIMATE,
-            "requiredFunctionNos": ["1001", "10300001"],
+            "requiredFunctionNos": ["1001", "10300001", "1015"],
         }
     ),
     CommandGateRule.model_validate(

--- a/src/pybyd/models/latest_config.py
+++ b/src/pybyd/models/latest_config.py
@@ -37,8 +37,8 @@ FEATURE_REGISTRY: tuple[FeatureSpec, ...] = (
     # Direct-control commands.
     FeatureSpec("lock", "Lock doors", ("1005",), "command"),
     FeatureSpec("unlock", "Unlock doors", ("1006",), "command"),
-    FeatureSpec("climate", "Climate (HVAC)", ("1001", "10300001"), "command"),
-    FeatureSpec("car_on", "Car on / one-tap prep", ("1001", "10300001"), "command"),
+    FeatureSpec("climate", "Climate (HVAC)", ("1001", "10300001", "1015"), "command"),
+    FeatureSpec("car_on", "Car on / one-tap prep", ("1001", "10300001", "1015"), "command"),
     FeatureSpec("battery_heat", "Battery heating", ("10300002",), "command"),
     FeatureSpec("steering_wheel_heat", "Steering-wheel heat", ("10030010", "10300004"), "command"),
     FeatureSpec("driver_seat_heat", "Driver seat heat", ("10030002", "10300003"), "command"),

--- a/tests/test_command_gating.py
+++ b/tests/test_command_gating.py
@@ -157,6 +157,21 @@ class TestLearnInfoGate:
 class TestEvaluateCommandGatePublicSurface:
     """Top-level ``evaluate_command_gate`` accepts and forwards ``learn_info``."""
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            RemoteCommand.START_CLIMATE,
+            RemoteCommand.STOP_CLIMATE,
+            RemoteCommand.SCHEDULE_CLIMATE,
+        ],
+    )
+    def test_electric_ac_function_no_allows_climate_commands(self, command: RemoteCommand):
+        """Vehicles that advertise Electric A/C as 1015 can use HVAC commands."""
+        verdict = evaluate_command_gate(command, _caps_with(["1015"]))
+        assert verdict.supported is True
+        assert verdict.reason == "supported"
+        assert verdict.matched_function_nos == ["1015"]
+
     def test_open_windows_blocked_when_learn_info_off(self):
         """The shipped OPEN_WINDOWS rule rejects when learn_info=0."""
         verdict = evaluate_command_gate(

--- a/tests/test_latest_config.py
+++ b/tests/test_latest_config.py
@@ -133,9 +133,29 @@ def test_from_latest_config_marks_each_registry_feature_supported_or_not() -> No
 )
 def test_specific_capability_resolution(expected_key: str, should_be: bool) -> None:
     caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(_OVERSEAS_FUNCTION_NOS))
-    assert (
-        getattr(caps, expected_key) is should_be
-    ), f"expected {expected_key} to be {should_be} for the test vehicle dump"
+    assert getattr(caps, expected_key) is should_be, (
+        f"expected {expected_key} to be {should_be} for the test vehicle dump"
+    )
+
+
+def test_electric_ac_function_no_enables_climate_capability() -> None:
+    """Some vehicles report remote HVAC as Electric A/C functionNo 1015."""
+    latest = VehicleLatestConfig.model_validate(
+        {
+            "cfFixedList": [
+                {
+                    "code": "Electric A/C",
+                    "functionName": "电动空调",
+                    "functionNo": "1015",
+                    "sortNum": 15,
+                }
+            ]
+        }
+    )
+    caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", latest)
+    assert caps.climate is True
+    assert caps.car_on is True
+    assert caps.unknown_function_nos == []
 
 
 def test_supported_summary_pins_count() -> None:


### PR DESCRIPTION
A BYD Seagull / Dolphin Surf reports remote A/C as:
```json
{
  "code": "Electric A/C",
  "functionName": "电动空调",
  "functionNo": "1015",
  "sortNum": 15
}