### PR TITLE
fix(mqtt): release paho sockets on stop() (file-descriptor leak)

### DIFF
--- a/src/pybyd/_mqtt.py
+++ b/src/pybyd/_mqtt.py
@@ -271,16 +271,31 @@ class BydMqttRuntime:
         """Stop and disconnect current MQTT client if running."""
         client = self._client
         self._client = None
-        was_running = self._running
         self._running = False
         self._topic = None
 
         if client is None:
             return
         try:
-            if was_running:
-                self._logger.debug("MQTT disconnect requested")
-                client.disconnect()
+            # Request a graceful DISCONNECT unconditionally — even a refused /
+            # never-acked connection can hold a half-open socket.
+            self._logger.debug("MQTT disconnect requested")
+            client.disconnect()
+        except Exception:  # noqa: BLE001
+            pass
         finally:
             client.loop_stop()
-            self._logger.debug("MQTT network loop stopped")
+            # paho's disconnect()/loop_stop() do NOT deterministically close
+            # the TLS socket — it is otherwise only reclaimed at GC (__del__).
+            # Under frequent restarts (re-auth on session expiry / token
+            # invalidation, key-refresh) the leaked file descriptors accumulate
+            # and can eventually exhaust the host's FD limit ([Errno 24]),
+            # taking the process down. Force the TLS socket + the loop_start
+            # self-pipe closed right now.
+            with contextlib.suppress(Exception):
+                client._reset_sockets()  # closes _sock (TLS) + socketpair
+            with contextlib.suppress(Exception):
+                sock = client.socket()
+                if sock is not None:
+                    sock.close()
+            self._logger.debug("MQTT network loop stopped (sockets released)")

--- a/src/pybyd/_version.py
+++ b/src/pybyd/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '0.1.dev2+ge0a1f5e27'
-__version_tuple__ = version_tuple = (0, 1, 'dev2', 'ge0a1f5e27')
+__version__ = version = '0.0.71.dev1+g8ec33b782.d20260602'
+__version_tuple__ = version_tuple = (0, 0, 71, 'dev1', 'g8ec33b782.d20260602')
 
 __commit_id__ = commit_id = None


### PR DESCRIPTION
## Problem

`BydMqttRuntime.stop()` calls `client.disconnect()` + `client.loop_stop()`, but paho-mqtt does **not** close the underlying TLS socket there — `loop_stop()` only joins the network thread, and the socket FD (plus the `loop_start()` self-pipe) is only reclaimed later when the `mqtt.Client` is garbage-collected (`__del__` → `_reset_sockets`).

The MQTT runtime is torn down and recreated on **every** re-auth (`login()` → `_stop_mqtt()` + restart), which fires on session-token expiry/invalidation, key refresh, etc. Each restart therefore leaves ~3 file descriptors open until GC instead of releasing them at teardown. Over a long-running process with frequent re-auth this is an unnecessary FD accumulation that only the garbage collector eventually reclaims, and which can contribute to FD pressure on the host over time.

## Evidence

Minimal, self-contained repro (6 TLS paho clients, same construction as the runtime — `tls_set()` + `connect_async` + `loop_start`):

```
base = 4 FDs
6 clients connecting                     -> 22 FDs (+18, ~3 per client)
after disconnect() + loop_stop()         -> still +18  (only reclaimed at GC)
after _reset_sockets() + socket().close() -> 4 FDs (+0) ← reclaimed immediately
```

So `disconnect()` + `loop_stop()` alone leave the sockets open; forcing them closed reclaims the FDs deterministically. This is independent of any particular deployment — it reproduces with plain paho.

## Fix

Make `stop()` release the socket deterministically: after `loop_stop()`, force-close the TLS socket and the self-pipe (`client._reset_sockets()` + `client.socket().close()`, both guarded). Also issue `disconnect()` unconditionally so a refused/never-acked connection's half-open socket is torn down too. No change to reconnect behaviour — this only guarantees the FDs are reclaimed at teardown instead of waiting for GC.

Verified: with the change, the repro above returns to baseline FDs immediately after teardown.