### PR TITLE
feat(errors): map 1008 → BydServiceBusyError, 6002 → BydDataUnavailableError

### DIFF
--- a/src/pybyd/__init__.py
+++ b/src/pybyd/__init__.py
@@ -16,6 +16,7 @@ from pybyd.exceptions import (
     BydError,
     BydRateLimitError,
     BydRemoteControlError,
+    BydServiceBusyError,
     BydSessionExpiredError,
     BydTransportError,
 )
@@ -57,6 +58,7 @@ __all__ = [
     "BydError",
     "BydRateLimitError",
     "BydRemoteControlError",
+    "BydServiceBusyError",
     "BydSessionExpiredError",
     "BydTransportError",
     "CommandAckEvent",

--- a/src/pybyd/_api/_common.py
+++ b/src/pybyd/_api/_common.py
@@ -24,7 +24,9 @@ from pybyd._transport import Transport
 from pybyd.config import BydConfig
 from pybyd.exceptions import (
     BydApiError,
+    BydDataUnavailableError,
     BydEndpointNotSupportedError,
+    BydServiceBusyError,
     BydSessionExpiredError,
 )
 from pybyd.session import Session
@@ -33,6 +35,12 @@ _logger = logging.getLogger(__name__)
 
 #: API error codes indicating the endpoint is not supported for this vehicle.
 ENDPOINT_NOT_SUPPORTED_CODES: frozenset[str] = frozenset({"1001"})
+
+#: Backend busy / soft rate-limit — recoverable, callers should back off.
+SERVICE_BUSY_CODES: frozenset[str] = frozenset({"1008"})
+
+#: Vehicle temporarily unreachable (deep sleep / offline) — retain last value.
+VEHICLE_UNREACHABLE_CODES: frozenset[str] = frozenset({"6002"})
 
 
 def build_inner_base(
@@ -100,6 +108,19 @@ def _raise_for_code(
                     code=code,
                     endpoint=endpoint,
                 )
+    # Default mappings applied to EVERY endpoint (after per-call overrides).
+    if code in SERVICE_BUSY_CODES:
+        raise BydServiceBusyError(
+            f"{endpoint} failed: code={code} message={message}",
+            code=code,
+            endpoint=endpoint,
+        )
+    if code in VEHICLE_UNREACHABLE_CODES:
+        raise BydDataUnavailableError(
+            f"{endpoint} failed: code={code} message={message}",
+            code=code,
+            endpoint=endpoint,
+        )
     raise BydApiError(
         f"{endpoint} failed: code={code} message={message}",
         code=code,

--- a/src/pybyd/exceptions.py
+++ b/src/pybyd/exceptions.py
@@ -107,3 +107,16 @@ class BydRateLimitError(BydApiError):
     This is raised when the server returns code 6024 after exhausting
     all automatic retry attempts.
     """
+
+
+class BydServiceBusyError(BydApiError):
+    """Backend busy / soft rate-limit (code 1008, "Error de servicio").
+
+    The dominant transient failure on EU cars: the cloud returns ``1008``
+    for realtime/GPS/charging reads when it is overloaded or the car is
+    deep-asleep and the backend gives up. It is recoverable — consumers
+    should retain last-known data and BACK OFF (lengthen the poll
+    interval) rather than hammer, since bursts of ``1008`` mean the
+    backend wants fewer requests. Subclasses :class:`BydApiError` so
+    existing recoverable-error handling keeps working unchanged.
+    """

--- a/tests/test_latest_config.py
+++ b/tests/test_latest_config.py
@@ -133,9 +133,9 @@ def test_from_latest_config_marks_each_registry_feature_supported_or_not() -> No
 )
 def test_specific_capability_resolution(expected_key: str, should_be: bool) -> None:
     caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(_OVERSEAS_FUNCTION_NOS))
-    assert getattr(caps, expected_key) is should_be, (
-        f"expected {expected_key} to be {should_be} for the test vehicle dump"
-    )
+    assert (
+        getattr(caps, expected_key) is should_be
+    ), f"expected {expected_key} to be {should_be} for the test vehicle dump"
 
 
 def test_electric_ac_function_no_enables_climate_capability() -> None:

--- a/tests/test_service_busy_error_mapping.py
+++ b/tests/test_service_busy_error_mapping.py
@@ -1,0 +1,82 @@
+"""Tests for the default 1008/6002 API error-code mappings.
+
+``_raise_for_code`` applies these mappings on *every* endpoint, after any
+per-call ``extra_code_map`` overrides:
+
+- ``1008`` (backend busy / soft rate-limit) -> :class:`BydServiceBusyError`
+- ``6002`` (vehicle unreachable) -> :class:`BydDataUnavailableError`
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pybyd._api._common import _raise_for_code
+from pybyd.exceptions import (
+    BydApiError,
+    BydDataUnavailableError,
+    BydRemoteControlError,
+    BydServiceBusyError,
+)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/control/remoteControl",
+        "/vehicleInfo/vehicle/vehicleRealTimeRequest",
+        "/control/smartCharge/homePage",
+    ],
+)
+def test_1008_maps_to_service_busy_on_every_endpoint(endpoint: str) -> None:
+    """1008 surfaces as BydServiceBusyError regardless of endpoint."""
+    with pytest.raises(BydServiceBusyError) as exc_info:
+        _raise_for_code(endpoint=endpoint, code="1008", message="Error de servicio")
+
+    assert exc_info.value.code == "1008"
+    assert exc_info.value.endpoint == endpoint
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/control/remoteControl",
+        "/vehicleInfo/vehicle/vehicleRealTimeRequest",
+    ],
+)
+def test_6002_maps_to_data_unavailable_on_every_endpoint(endpoint: str) -> None:
+    """6002 surfaces as BydDataUnavailableError regardless of endpoint."""
+    with pytest.raises(BydDataUnavailableError) as exc_info:
+        _raise_for_code(endpoint=endpoint, code="6002", message="weak signal")
+
+    assert exc_info.value.code == "6002"
+
+
+def test_service_busy_is_apierror_subclass() -> None:
+    """Non-breaking: existing ``except BydApiError`` callers still catch it."""
+    assert issubclass(BydServiceBusyError, BydApiError)
+    with pytest.raises(BydApiError):
+        _raise_for_code(endpoint="/x", code="1008", message="m")
+
+
+def test_per_call_override_takes_precedence_over_default() -> None:
+    """A per-call ``extra_code_map`` entry wins over the default 1008 mapping."""
+    with pytest.raises(BydRemoteControlError) as exc_info:
+        _raise_for_code(
+            endpoint="/control/remoteControl",
+            code="1008",
+            message="m",
+            extra_code_map={frozenset({"1008"}): BydRemoteControlError},
+        )
+
+    assert exc_info.value.code == "1008"
+
+
+def test_unmapped_code_still_generic_api_error() -> None:
+    """Codes outside the default sets keep falling back to BydApiError."""
+    with pytest.raises(BydApiError) as exc_info:
+        _raise_for_code(endpoint="/x", code="9999", message="unknown")
+
+    # Not one of the specialised subclasses.
+    assert type(exc_info.value) is BydApiError
+    assert exc_info.value.code == "9999"


### PR DESCRIPTION
## What

Add two **default** API error-code mappings in `_raise_for_code`, applied to every endpoint (after any per-call `extra_code_map` overrides):

- **`1008`** ("Error de servicio" — backend busy / soft rate-limit / car deep-asleep) → new **`BydServiceBusyError`**
- **`6002`** (vehicle unreachable) → existing **`BydDataUnavailableError`**

## Why

`1008` is the dominant transient failure on the EU backend (thousands overnight in one capture) and was surfacing as a generic `BydApiError`, so callers couldn't distinguish it to back off / retry. `6002` (weak signal around the vehicle / deep sleep) deserves the same first-class treatment so integrations can keep the last-known value instead of erroring hard.

## Notes

- `BydServiceBusyError` subclasses `BydApiError`, so existing `except BydApiError` handlers keep working — **non-breaking**.
- Per-call `extra_code_map` still takes precedence over these defaults.

## Tests

New `tests/test_service_busy_error_mapping.py` (8 cases): 1008/6002 mapping across multiple endpoints, subclass/non-breaking guard, override precedence, and unmapped-code fallback. Full suite green (171 passed).