### PR TITLE
fix(control): surface real remote-control outcomes (no more optimistic success)

### DIFF
--- a/src/pybyd/_api/control.py
+++ b/src/pybyd/_api/control.py
@@ -370,13 +370,11 @@ async def _poll_remote_control_once(
         # we can never correlate an ack, so we cannot confirm execution.
         # Surface this instead of fabricating a tentative-success result.
         _logger.debug(
-            "Remote control %s returned no serial and no terminal result; "
-            "cannot confirm execution",
+            "Remote control %s returned no serial and no terminal result; " "cannot confirm execution",
             command.name,
         )
         raise BydRemoteControlError(
-            f"Remote control {command.name} could not be confirmed "
-            f"(vehicle returned no request serial)",
+            f"Remote control {command.name} could not be confirmed " f"(vehicle returned no request serial)",
             code="no_serial",
             endpoint="/control/remoteControl",
         )
@@ -400,8 +398,7 @@ async def _poll_remote_control_once(
                     )
                     if mqtt_result.control_state == 2:
                         raise BydRemoteControlError(
-                            f"Remote control {command.name} rejected by vehicle "
-                            f"(controlState=2)",
+                            f"Remote control {command.name} rejected by vehicle " f"(controlState=2)",
                             code="2",
                             endpoint="/control/remoteControl",
                         )
@@ -470,8 +467,7 @@ async def _poll_remote_control_once(
         # typically a deep-asleep/offline car. Surface it as a timeout instead
         # of returning a quiet pending result that callers read as success.
         raise BydRemoteControlError(
-            f"Remote control {command.name} not confirmed within timeout "
-            f"(vehicle may be asleep or offline)",
+            f"Remote control {command.name} not confirmed within timeout " f"(vehicle may be asleep or offline)",
             code="timeout",
             endpoint="/control/remoteControlResult",
         )

--- a/src/pybyd/_api/control.py
+++ b/src/pybyd/_api/control.py
@@ -366,8 +366,20 @@ async def _poll_remote_control_once(
         return parsed
 
     if not serial:
-        _logger.debug("Remote control %s request returned without serial; using immediate result", command.name)
-        return parse_remote_control_result_data(result if isinstance(result, dict) else {})
+        # No serial and the immediate result isn't terminal (checked above):
+        # we can never correlate an ack, so we cannot confirm execution.
+        # Surface this instead of fabricating a tentative-success result.
+        _logger.debug(
+            "Remote control %s returned no serial and no terminal result; "
+            "cannot confirm execution",
+            command.name,
+        )
+        raise BydRemoteControlError(
+            f"Remote control {command.name} could not be confirmed "
+            f"(vehicle returned no request serial)",
+            code="no_serial",
+            endpoint="/control/remoteControl",
+        )
 
     if mqtt_result_waiter is not None:
         try:
@@ -386,6 +398,13 @@ async def _poll_remote_control_once(
                         mqtt_result.success,
                         mqtt_result.control_state,
                     )
+                    if mqtt_result.control_state == 2:
+                        raise BydRemoteControlError(
+                            f"Remote control {command.name} rejected by vehicle "
+                            f"(controlState=2)",
+                            code="2",
+                            endpoint="/control/remoteControl",
+                        )
                     return mqtt_result
             _logger.debug("Remote control %s mqtt_wait returned no result; falling back to polling", command.name)
         except Exception:
@@ -393,6 +412,7 @@ async def _poll_remote_control_once(
 
     # Phase 2: Poll for results
     latest = result
+    reached_terminal = False
     for attempt in range(1, poll_attempts + 1):
         if poll_interval > 0:
             await asyncio.sleep(poll_interval)
@@ -415,6 +435,7 @@ async def _poll_remote_control_once(
                 serial,
             )
             if isinstance(latest, dict) and _is_remote_control_ready(latest):
+                reached_terminal = True
                 break
         except BydSessionExpiredError:
             raise
@@ -442,6 +463,16 @@ async def _poll_remote_control_once(
         raise BydRemoteControlError(
             f"Remote control {command.name} failed: {msg}",
             code="2",
+            endpoint="/control/remoteControlResult",
+        )
+    if not reached_terminal:
+        # Loop exhausted without the cloud ever returning a terminal result —
+        # typically a deep-asleep/offline car. Surface it as a timeout instead
+        # of returning a quiet pending result that callers read as success.
+        raise BydRemoteControlError(
+            f"Remote control {command.name} not confirmed within timeout "
+            f"(vehicle may be asleep or offline)",
+            code="timeout",
             endpoint="/control/remoteControlResult",
         )
     return parsed

--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -373,8 +373,7 @@ class BydCar:
                 # Roll back the optimistic state and surface the error instead
                 # of painting a fake "success" that the next poll would undo.
                 _logger.debug(
-                    "Remote control not confirmed for vin=%s (cmd=%s) — "
-                    "rolling back projection and raising",
+                    "Remote control not confirmed for vin=%s (cmd=%s) — " "rolling back projection and raising",
                     self._vin,
                     command_id,
                 )

--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -357,23 +357,30 @@ class BydCar:
         1. Acquire the per-VIN lock (serialises commands)
         2. Register projections (optimistic state update)
         3. Execute the command
-        4. On ``BydRemoteControlError`` — treat as tentative success
-        5. On other errors — rollback projections and re-raise
+        4. On ANY error (incl. ``BydRemoteControlError`` rejection/timeout) —
+           rollback projections and re-raise so the failure surfaces
 
-        No post-command reconcile poll is performed.  The projections
-        provide immediate optimistic state and the next regular poll
-        cycle (or MQTT push) will reconcile actual vehicle state.
+        The optimistic projection only persists when the command actually
+        succeeded; the next regular poll cycle (or MQTT push) reconciles
+        actual vehicle state.
         """
         async with self._engine.lock:
             command_id = self._engine.register_projections(projections) if projections else ""
             try:
                 await command_fn()
             except BydRemoteControlError:
+                # Command not confirmed (rejected / timeout / car asleep).
+                # Roll back the optimistic state and surface the error instead
+                # of painting a fake "success" that the next poll would undo.
                 _logger.debug(
-                    "BydRemoteControlError treated as tentative success for vin=%s (cmd=%s)",
+                    "Remote control not confirmed for vin=%s (cmd=%s) — "
+                    "rolling back projection and raising",
                     self._vin,
                     command_id,
                 )
+                if command_id:
+                    self._engine.rollback_projections(command_id)
+                raise
             except Exception:
                 if command_id:
                     self._engine.rollback_projections(command_id)

--- a/tests/test_command_outcomes.py
+++ b/tests/test_command_outcomes.py
@@ -49,9 +49,7 @@ async def test_no_serial_raises_instead_of_tentative_success(monkeypatch: pytest
     )
 
     with pytest.raises(BydRemoteControlError) as exc_info:
-        await _poll_remote_control_once(
-            None, None, None, "VIN", RemoteCommand.FLASH_LIGHTS, mqtt_result_waiter=None
-        )
+        await _poll_remote_control_once(None, None, None, "VIN", RemoteCommand.FLASH_LIGHTS, mqtt_result_waiter=None)
 
     assert exc_info.value.code == "no_serial"
 

--- a/tests/test_command_outcomes.py
+++ b/tests/test_command_outcomes.py
@@ -1,0 +1,133 @@
+"""Tests for surfacing real remote-control outcomes.
+
+Two halves of the behaviour:
+
+1. ``_poll_remote_control_once`` raises ``BydRemoteControlError`` instead of
+   returning a fabricated tentative-success result when the command can never
+   be confirmed (no request serial, or the poll loop times out).
+2. ``BydCar._execute_command`` rolls back the optimistic projection and
+   re-raises on ``BydRemoteControlError`` rather than swallowing it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+import pybyd._api.control as control
+from pybyd._api.control import _poll_remote_control_once
+from pybyd.car import BydCar
+from pybyd.exceptions import BydRemoteControlError
+from pybyd.models.control import RemoteCommand
+
+
+def _make_fetch_stub(responses: list[tuple[dict[str, Any], str | None]]):
+    """Return an async stub for ``_fetch_control_endpoint``.
+
+    Yields the queued ``(result, serial)`` tuples in order; repeats the last
+    one once exhausted so poll loops of any length stay fed.
+    """
+    calls = {"i": 0}
+
+    async def _stub(endpoint: str, *args: Any, **kwargs: Any) -> tuple[dict[str, Any], str | None]:
+        idx = min(calls["i"], len(responses) - 1)
+        calls["i"] += 1
+        return responses[idx]
+
+    return _stub
+
+
+@pytest.mark.asyncio
+async def test_no_serial_raises_instead_of_tentative_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Trigger returns a non-terminal result with no serial -> raise."""
+    monkeypatch.setattr(
+        control,
+        "_fetch_control_endpoint",
+        _make_fetch_stub([({}, None)]),
+    )
+
+    with pytest.raises(BydRemoteControlError) as exc_info:
+        await _poll_remote_control_once(
+            None, None, None, "VIN", RemoteCommand.FLASH_LIGHTS, mqtt_result_waiter=None
+        )
+
+    assert exc_info.value.code == "no_serial"
+
+
+@pytest.mark.asyncio
+async def test_timeout_raises_when_poll_never_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Serial present but the poll loop never reaches a terminal state -> timeout."""
+    # Trigger: has serial, not terminal. Polls: res=1 (in progress) forever.
+    monkeypatch.setattr(
+        control,
+        "_fetch_control_endpoint",
+        _make_fetch_stub([({"requestSerial": "S1"}, "S1"), ({"res": 1}, "S1")]),
+    )
+
+    with pytest.raises(BydRemoteControlError) as exc_info:
+        await _poll_remote_control_once(
+            None,
+            None,
+            None,
+            "VIN",
+            RemoteCommand.FLASH_LIGHTS,
+            poll_attempts=2,
+            poll_interval=0,
+            mqtt_result_waiter=None,
+        )
+
+    assert exc_info.value.code == "timeout"
+
+
+class _FakeEngine:
+    """Minimal state-engine stand-in tracking projection lifecycle calls."""
+
+    def __init__(self) -> None:
+        self.lock = asyncio.Lock()
+        self.registered = 0
+        self.rolled_back: list[str] = []
+
+    def register_projections(self, specs: Any) -> str:
+        self.registered += 1
+        return "cmd-1"
+
+    def rollback_projections(self, command_id: str) -> None:
+        self.rolled_back.append(command_id)
+
+
+class _StubCar:
+    """Just enough of BydCar to drive _execute_command."""
+
+    def __init__(self) -> None:
+        self._engine = _FakeEngine()
+        self._vin = "VIN"
+
+
+@pytest.mark.asyncio
+async def test_execute_command_rolls_back_and_reraises_on_control_error() -> None:
+    """A BydRemoteControlError rolls back the projection and propagates."""
+    car = _StubCar()
+
+    async def _failing() -> None:
+        raise BydRemoteControlError("rejected", code="2", endpoint="/control/remoteControl")
+
+    with pytest.raises(BydRemoteControlError):
+        await BydCar._execute_command(car, _failing, ["projection"])
+
+    assert car._engine.rolled_back == ["cmd-1"]
+
+
+@pytest.mark.asyncio
+async def test_execute_command_keeps_projection_on_success() -> None:
+    """A successful command must NOT roll back the optimistic projection."""
+    car = _StubCar()
+
+    async def _ok() -> None:
+        return None
+
+    await BydCar._execute_command(car, _ok, ["projection"])
+
+    assert car._engine.registered == 1
+    assert car._engine.rolled_back == []

--- a/tests/test_latest_config.py
+++ b/tests/test_latest_config.py
@@ -133,9 +133,9 @@ def test_from_latest_config_marks_each_registry_feature_supported_or_not() -> No
 )
 def test_specific_capability_resolution(expected_key: str, should_be: bool) -> None:
     caps = VehicleCapabilities.from_latest_config("VIN_PLACEHOLDER", _build_latest(_OVERSEAS_FUNCTION_NOS))
-    assert getattr(caps, expected_key) is should_be, (
-        f"expected {expected_key} to be {should_be} for the test vehicle dump"
-    )
+    assert (
+        getattr(caps, expected_key) is should_be
+    ), f"expected {expected_key} to be {should_be} for the test vehicle dump"
 
 
 def test_electric_ac_function_no_enables_climate_capability() -> None:


### PR DESCRIPTION
## Problem

A remote command that the cloud never confirms was treated as **tentative success**: `_poll_remote_control_once` returned a fabricated result and `BydCar._execute_command` swallowed `BydRemoteControlError`, leaving the optimistic projection in place. The HA switch/select would flip to the chosen value even though the car never acted (typically because it was asleep/offline), then silently revert on the next poll — looking like "nothing happened" with no error.

## Change

`_poll_remote_control_once` now raises `BydRemoteControlError` instead of inventing success when the command cannot be confirmed:
- **no request serial** + non-terminal immediate result → `code="no_serial"`
- **MQTT ack with `controlState=2`** (rejected) → `code="2"`
- **poll loop exhausted** without a terminal result (deep-asleep/offline car) → `code="timeout"`

`BydCar._execute_command` now **rolls back the optimistic projection and re-raises** on `BydRemoteControlError` instead of treating it as tentative success. The projection only persists when the command actually succeeded.

## Result

Callers get a real error they can show/handle, and the UI no longer paints a fake success that the next poll undoes.

## Tests

New `tests/test_command_outcomes.py`: no-serial and timeout raises in `_poll_remote_control_once` (via a stubbed `_fetch_control_endpoint`), plus rollback-and-reraise vs keep-on-success in `_execute_command`. Full suite green.