### PR TITLE
feat(control): add stop_charging (symmetric to start_charging)

### DIFF
--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -247,6 +247,17 @@ class BydCar:
         """
         return await self._client.start_charging(self._vin)
 
+    async def stop_charging(self) -> ChargeChangeResult:
+        """Stop charging immediately and wait for the toggle to settle.
+
+        Symmetric to :meth:`start_charging`; routes through the same
+        ``_trigger_and_poll`` pipeline with ``status: "0"``.
+
+        Raises :class:`BydRemoteControlError` if the toggle reports
+        failure or doesn't settle within the polling window.
+        """
+        return await self._client.stop_charging(self._vin)
+
     async def update_energy(self) -> EnergyConsumption:
         """Fetch fresh energy consumption data and merge into state engine."""
         data = await self._client.get_energy_consumption(self._vin)

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1596,6 +1596,78 @@ class BydClient:
 
         return await self._call_with_reauth(_call)
 
+    async def stop_charging(
+        self,
+        vin: str,
+        *,
+        mqtt_timeout: float | None = None,
+        poll_attempts: int = 6,
+        poll_interval: float = 2.0,
+    ) -> ChargeChangeResult:
+        """Stop charging immediately and wait for the toggle to settle.
+
+        Symmetric to :meth:`start_charging` — gates on the same
+        ``functionNo "1012"`` (``RESERVATIONCHARGING``) and routes through
+        :meth:`_trigger_and_poll`, but triggers
+        ``/control/smartCharge/changeChargeStatue`` with ``status: "0"``.
+
+        Returns the terminal :class:`ChargeChangeResult` (``res == 2``).
+        Raises :class:`BydRemoteControlError` for terminal failures
+        (``res > 2``) or if neither MQTT nor polling produced a terminal
+        result within the polling window.
+        """
+        capabilities = await self.get_vehicle_capabilities(vin)
+        learn_info = await self._vehicle_fun_learn_info_for(vin)
+        gate = evaluate_command_gate(RemoteCommand.STOP_CHARGE, capabilities, learn_info=learn_info)
+        if not gate.supported:
+            raise BydEndpointNotSupportedError(
+                (f"stop_charging blocked for VIN {vin}: " f"gate={gate.gate_id} reason={gate.reason}"),
+                code="command_gate_blocked",
+                endpoint="/control/smartCharge/changeChargeStatue",
+            )
+
+        async def _call() -> ChargeChangeResult:
+            result = await self._trigger_and_poll(
+                vin=vin,
+                trigger_endpoint="/control/smartCharge/changeChargeStatue",
+                poll_endpoint="/control/smartCharge/changeResult",
+                fetch_fn=_smart_api.make_change_charge_fetch_fn(start=False),
+                is_ready=_smart_api.is_charge_change_ready,
+                model_cls=ChargeChangeResult,
+                label="ChargeStop",
+                mqtt_event_type="smartCharge",
+                mqtt_timeout=mqtt_timeout,
+                poll_attempts=poll_attempts,
+                poll_interval=poll_interval,
+            )
+            res = result.res
+            if res == 2:
+                return result
+            if res is None:
+                raise BydRemoteControlError(
+                    "smartCharge change_charge_status timed out without a terminal result",
+                    code="timeout",
+                    endpoint="/control/smartCharge/changeResult",
+                )
+            # res=3 mirrors start_charging: the cloud treats the vehicle as
+            # "already in target state" — here a duplicate stop request or a
+            # vehicle that is not charging.
+            if res == 3:
+                raise BydRemoteControlError(
+                    f"smartCharge change_charge_status rejected by cloud (res=3, "
+                    f"message={result.message!r}) — vehicle is likely already in "
+                    "the target state (not charging, or a duplicate stop request)",
+                    code="3",
+                    endpoint="/control/smartCharge/changeResult",
+                )
+            raise BydRemoteControlError(
+                f"smartCharge change_charge_status unexpected res={res} message={result.message}",
+                code=str(res),
+                endpoint="/control/smartCharge/changeResult",
+            )
+
+        return await self._call_with_reauth(_call)
+
     async def rename_vehicle(self, vin: str, *, name: str) -> CommandAck:
         """Rename a vehicle."""
         return await self._authed_call(_settings_api.rename_vehicle, vin, name=name)

--- a/src/pybyd/models/command_gating.py
+++ b/src/pybyd/models/command_gating.py
@@ -183,6 +183,15 @@ _COMMAND_GATE_RULES: tuple[CommandGateRule, ...] = (
             "requiredFunctionNos": ["1012"],
         }
     ),
+    CommandGateRule.model_validate(
+        {
+            # Stopping uses the same `RESERVATIONCHARGING` (`1012`) capability
+            # as starting — the changeChargeStatue toggle with ``status: "0"``.
+            "gateId": "stop_charge",
+            "command": RemoteCommand.STOP_CHARGE,
+            "requiredFunctionNos": ["1012"],
+        }
+    ),
 )
 
 # Seat command requires explicit target selection via control_params.chairType.

--- a/src/pybyd/models/control.py
+++ b/src/pybyd/models/control.py
@@ -43,13 +43,14 @@ class RemoteCommand(enum.StrEnum):
     BATTERY_HEAT = "BATTERYHEAT"
     OPEN_TRUNK = "OPENTRUNK"
     CLOSE_TRUNK = "CLOSETRUNK"
-    # `START_CHARGE` is a synthetic value (never sent on the wire as a
-    # `commandType`).  The on-the-wire smart-charging "start" toggle goes via
-    # `/control/smartCharge/changeChargeStatue` with ``status: "1"`` rather
-    # than `/control/remoteControl`.  We add the enum member so the gating
-    # table can express the `functionNo` requirement (``1012``) for callers
-    # that introspect command availability.
+    # `START_CHARGE` / `STOP_CHARGE` are synthetic values (never sent on the
+    # wire as a `commandType`).  The on-the-wire smart-charging toggle goes via
+    # `/control/smartCharge/changeChargeStatue` with ``status: "1"`` (start) or
+    # ``status: "0"`` (stop) rather than `/control/remoteControl`.  We add the
+    # enum members so the gating table can express the `functionNo` requirement
+    # (``1012``) for callers that introspect command availability.
     START_CHARGE = "SMARTCHARGESTART"
+    STOP_CHARGE = "SMARTCHARGESTOP"
 
 
 class ControlState(enum.IntEnum):

--- a/tests/test_stop_charging.py
+++ b/tests/test_stop_charging.py
@@ -1,0 +1,52 @@
+"""Tests for the stop_charging command gate.
+
+``stop_charging`` mirrors ``start_charging``: both gate on the
+``RESERVATIONCHARGING`` capability (``functionNo "1012"``) and toggle
+``/control/smartCharge/changeChargeStatue`` (``status: "0"`` to stop).
+"""
+
+from __future__ import annotations
+
+from pybyd.models.command_gating import evaluate_command_gate
+from pybyd.models.control import RemoteCommand
+from pybyd.models.latest_config import VehicleCapabilities
+
+
+def _caps_with(function_nos: list[str]) -> VehicleCapabilities:
+    return VehicleCapabilities.model_validate(
+        {
+            "vin": "TEST" + "X" * 13,
+            "source": "test_fixture",
+            "functionNos": function_nos,
+        }
+    )
+
+
+def test_stop_charge_enum_value() -> None:
+    """Synthetic enum member carries the BYD commandType string."""
+    assert RemoteCommand.STOP_CHARGE == "SMARTCHARGESTOP"
+
+
+def test_stop_charge_supported_with_1012() -> None:
+    """Gate is supported when the car exposes functionNo 1012."""
+    verdict = evaluate_command_gate(RemoteCommand.STOP_CHARGE, _caps_with(["1012"]))
+    assert verdict.supported is True
+
+
+def test_stop_charge_blocked_without_1012() -> None:
+    """Gate is blocked when the car lacks functionNo 1012."""
+    verdict = evaluate_command_gate(RemoteCommand.STOP_CHARGE, _caps_with(["1005"]))
+    assert verdict.supported is False
+
+
+def test_stop_charge_gate_mirrors_start_charge() -> None:
+    """Start and stop gate on the same capability — symmetric availability."""
+    caps = _caps_with(["1012"])
+    start = evaluate_command_gate(RemoteCommand.START_CHARGE, caps)
+    stop = evaluate_command_gate(RemoteCommand.STOP_CHARGE, caps)
+    assert start.supported == stop.supported is True
+
+    caps_no = _caps_with([])
+    start_no = evaluate_command_gate(RemoteCommand.START_CHARGE, caps_no)
+    stop_no = evaluate_command_gate(RemoteCommand.STOP_CHARGE, caps_no)
+    assert start_no.supported == stop_no.supported is False


### PR DESCRIPTION
## What

Adds `stop_charging`, the missing counterpart to `start_charging`.

The smart-charging API already supports stopping — `trigger_charge_change(start=False)` posts `changeChargeStatue` with `status: "0"` — but there was no high-level method to call it. This wires it up symmetrically:

- `RemoteCommand.STOP_CHARGE` (`"SMARTCHARGESTOP"`, synthetic like `START_CHARGE`)
- a `stop_charge` command gate on the same `functionNo "1012"` (`RESERVATIONCHARGING`) that `start_charge` uses
- `BydClient.stop_charging()` mirroring `start_charging` (`start=False`, label `ChargeStop`; `res=3` surfaced as "already stopped / duplicate stop" instead of the locale-dependent "Operation failure")
- `BydCar.stop_charging()` wrapper

The `FEATURE_REGISTRY` already carries the `stop_charge` capability flag, so this completes the start/stop pair end to end.

## Tests

New `tests/test_stop_charging.py`: enum value, gate supported/blocked on `1012`, and start/stop gate symmetry. Full suite green (179 passed); `ruff` / `black` / `mypy src/pybyd` clean.