### PR TITLE
fix(control): stop_charging raises instead of reporting a false success

### DIFF
--- a/src/pybyd/car.py
+++ b/src/pybyd/car.py
@@ -248,13 +248,13 @@ class BydCar:
         return await self._client.start_charging(self._vin)
 
     async def stop_charging(self) -> ChargeChangeResult:
-        """Stop charging immediately and wait for the toggle to settle.
+        """Not supported — the BYD cloud cannot stop an active charge.
 
-        Symmetric to :meth:`start_charging`; routes through the same
-        ``_trigger_and_poll`` pipeline with ``status: "0"``.
-
-        Raises :class:`BydRemoteControlError` if the toggle reports
-        failure or doesn't settle within the polling window.
+        Delegates to :meth:`BydClient.stop_charging`, which always raises
+        :class:`BydEndpointNotSupportedError`: the ``changeChargeStatue``
+        ``status: "0"`` path is a verified no-op (reports success without
+        stopping). Stop an active charge with the key-fob/door-handle
+        double-unlock instead.
         """
         return await self._client.stop_charging(self._vin)
 

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1604,69 +1604,36 @@ class BydClient:
         poll_attempts: int = 6,
         poll_interval: float = 2.0,
     ) -> ChargeChangeResult:
-        """Stop charging immediately and wait for the toggle to settle.
+        """Not supported: the BYD cloud has no working stop-charge command.
 
-        Symmetric to :meth:`start_charging` — gates on the same
-        ``functionNo "1012"`` (``RESERVATIONCHARGING``) and routes through
-        :meth:`_trigger_and_poll`, but triggers
-        ``/control/smartCharge/changeChargeStatue`` with ``status: "0"``.
+        .. warning::
+           ``/control/smartCharge/changeChargeStatue`` with ``status: "0"``
+           is a **verified no-op** — ``changeResult`` returns
+           ``res: 2 "Operation successful"`` but the vehicle keeps charging
+           (live-tested; see ``references/changeChargeStatue.md``). The BYD
+           app has no in-app stop-charge action either; the only way to stop
+           an active charge is the key-fob / door-handle double-unlock, a
+           physical/CAN path with no cloud equivalent.
 
-        Returns the terminal :class:`ChargeChangeResult` (``res == 2``).
-        Raises :class:`BydRemoteControlError` for terminal failures
-        (``res > 2``) or if neither MQTT nor polling produced a terminal
-        result within the polling window.
+        This method therefore raises immediately instead of issuing the
+        request and reporting a false success. The ``mqtt_timeout`` /
+        ``poll_attempts`` / ``poll_interval`` parameters are retained only
+        to keep the signature symmetric with :meth:`start_charging`.
+
+        Raises
+        ------
+        BydEndpointNotSupportedError
+            Always — the cloud cannot stop an active charge.
         """
-        capabilities = await self.get_vehicle_capabilities(vin)
-        learn_info = await self._vehicle_fun_learn_info_for(vin)
-        gate = evaluate_command_gate(RemoteCommand.STOP_CHARGE, capabilities, learn_info=learn_info)
-        if not gate.supported:
-            raise BydEndpointNotSupportedError(
-                (f"stop_charging blocked for VIN {vin}: " f"gate={gate.gate_id} reason={gate.reason}"),
-                code="command_gate_blocked",
-                endpoint="/control/smartCharge/changeChargeStatue",
-            )
-
-        async def _call() -> ChargeChangeResult:
-            result = await self._trigger_and_poll(
-                vin=vin,
-                trigger_endpoint="/control/smartCharge/changeChargeStatue",
-                poll_endpoint="/control/smartCharge/changeResult",
-                fetch_fn=_smart_api.make_change_charge_fetch_fn(start=False),
-                is_ready=_smart_api.is_charge_change_ready,
-                model_cls=ChargeChangeResult,
-                label="ChargeStop",
-                mqtt_event_type="smartCharge",
-                mqtt_timeout=mqtt_timeout,
-                poll_attempts=poll_attempts,
-                poll_interval=poll_interval,
-            )
-            res = result.res
-            if res == 2:
-                return result
-            if res is None:
-                raise BydRemoteControlError(
-                    "smartCharge change_charge_status timed out without a terminal result",
-                    code="timeout",
-                    endpoint="/control/smartCharge/changeResult",
-                )
-            # res=3 mirrors start_charging: the cloud treats the vehicle as
-            # "already in target state" — here a duplicate stop request or a
-            # vehicle that is not charging.
-            if res == 3:
-                raise BydRemoteControlError(
-                    f"smartCharge change_charge_status rejected by cloud (res=3, "
-                    f"message={result.message!r}) — vehicle is likely already in "
-                    "the target state (not charging, or a duplicate stop request)",
-                    code="3",
-                    endpoint="/control/smartCharge/changeResult",
-                )
-            raise BydRemoteControlError(
-                f"smartCharge change_charge_status unexpected res={res} message={result.message}",
-                code=str(res),
-                endpoint="/control/smartCharge/changeResult",
-            )
-
-        return await self._call_with_reauth(_call)
+        raise BydEndpointNotSupportedError(
+            "stop_charging is not supported: the BYD cloud "
+            "changeChargeStatue status='0' is a verified no-op (returns "
+            "success but does not stop an active charge). Stop an active "
+            "charge with the key-fob/door-handle double-unlock instead. "
+            "See references/changeChargeStatue.md.",
+            code="cloud_stop_unsupported",
+            endpoint="/control/smartCharge/changeChargeStatue",
+        )
 
     async def rename_vehicle(self, vin: str, *, name: str) -> CommandAck:
         """Rename a vehicle."""

--- a/tests/test_stop_charging.py
+++ b/tests/test_stop_charging.py
@@ -1,12 +1,21 @@
-"""Tests for the stop_charging command gate.
+"""Tests for stop_charging.
 
-``stop_charging`` mirrors ``start_charging``: both gate on the
-``RESERVATIONCHARGING`` capability (``functionNo "1012"``) and toggle
-``/control/smartCharge/changeChargeStatue`` (``status: "0"`` to stop).
+The BYD cloud has no working stop-charge command: the
+``changeChargeStatue`` ``status: "0"`` path is a verified no-op (returns
+``res: 2 "Operation successful"`` while the vehicle keeps charging — see
+``references/changeChargeStatue.md``). ``BydClient.stop_charging`` therefore
+raises instead of reporting a false success.
+
+The ``STOP_CHARGE`` enum member and gate rule are retained as metadata (the
+command type exists in BYD's catalogue) and are still exercised here.
 """
 
 from __future__ import annotations
 
+import pytest
+
+from pybyd.client import BydClient
+from pybyd.exceptions import BydEndpointNotSupportedError
 from pybyd.models.command_gating import evaluate_command_gate
 from pybyd.models.control import RemoteCommand
 from pybyd.models.latest_config import VehicleCapabilities
@@ -27,26 +36,26 @@ def test_stop_charge_enum_value() -> None:
     assert RemoteCommand.STOP_CHARGE == "SMARTCHARGESTOP"
 
 
-def test_stop_charge_supported_with_1012() -> None:
-    """Gate is supported when the car exposes functionNo 1012."""
-    verdict = evaluate_command_gate(RemoteCommand.STOP_CHARGE, _caps_with(["1012"]))
-    assert verdict.supported is True
-
-
-def test_stop_charge_blocked_without_1012() -> None:
-    """Gate is blocked when the car lacks functionNo 1012."""
-    verdict = evaluate_command_gate(RemoteCommand.STOP_CHARGE, _caps_with(["1005"]))
-    assert verdict.supported is False
-
-
-def test_stop_charge_gate_mirrors_start_charge() -> None:
-    """Start and stop gate on the same capability — symmetric availability."""
+def test_stop_charge_gate_present_and_mirrors_start() -> None:
+    """The stop_charge gate exists and gates on the same capability as start."""
     caps = _caps_with(["1012"])
-    start = evaluate_command_gate(RemoteCommand.START_CHARGE, caps)
-    stop = evaluate_command_gate(RemoteCommand.STOP_CHARGE, caps)
-    assert start.supported == stop.supported is True
+    assert evaluate_command_gate(RemoteCommand.STOP_CHARGE, caps).supported is True
+    assert evaluate_command_gate(RemoteCommand.START_CHARGE, caps).supported is True
 
     caps_no = _caps_with([])
-    start_no = evaluate_command_gate(RemoteCommand.START_CHARGE, caps_no)
-    stop_no = evaluate_command_gate(RemoteCommand.STOP_CHARGE, caps_no)
-    assert start_no.supported == stop_no.supported is False
+    assert evaluate_command_gate(RemoteCommand.STOP_CHARGE, caps_no).supported is False
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_raises_unsupported() -> None:
+    """stop_charging refuses rather than issuing the known no-op request.
+
+    It must raise BEFORE any network/session work, so calling it on a bare
+    client instance (no session) still raises the unsupported error.
+    """
+    client = BydClient.__new__(BydClient)  # no __init__: prove no I/O happens
+    with pytest.raises(BydEndpointNotSupportedError) as exc_info:
+        await client.stop_charging("TEST" + "X" * 13)
+
+    assert exc_info.value.code == "cloud_stop_unsupported"
+    assert "no-op" in str(exc_info.value).lower()


### PR DESCRIPTION
Follow-up to #58.

I jumped the gun on #58 — `stop_charging` doesn't actually work. `references/changeChargeStatue.md` (already in the repo) documents `changeChargeStatue` with `status: "0"` as a **verified no-op**: `changeResult` returns `res: 2 "Operation successful"`, but the vehicle keeps charging (live-tested, both with default settings and after toggling the app's remote-charge options). The BYD app has no in-app stop-charge action — the real way to stop an active charge is the key-fob / door-handle double-unlock (a physical/CAN path with no cloud equivalent).

As merged, `stop_charging` reports success without doing anything, which would surface a misleading "Stop charging" button if the HA integration wired it up.

This makes `stop_charging` **raise `BydEndpointNotSupportedError` immediately** (no request issued) so callers get an honest signal. The `STOP_CHARGE` enum member and gate rule are kept as metadata in case a payload variant that genuinely stops an active charge is ever captured.

Alternative if you'd rather: a full revert of #58. Happy to switch to that — let me know. (This is also why I'd hold off on the hass-byd-vehicle stop button you asked about.)

## Tests
`tests/test_stop_charging.py` updated: enum + gate metadata still checked, plus a new test that `stop_charging` raises `BydEndpointNotSupportedError` (code `cloud_stop_unsupported`) before any I/O. Full suite green; ruff / black / mypy clean.