### PR TITLE
fix(push): correct EU push-switch endpoint + parse per-type list

### DIFF
--- a/src/pybyd/_api/push_notifications.py
+++ b/src/pybyd/_api/push_notifications.py
@@ -1,8 +1,10 @@
 """Push notification endpoints.
 
-Endpoints:
-  - /app/push/getPushSwitchState  (get current state)
-  - /app/push/setPushSwitchState  (toggle on/off)
+Endpoints (EU host uses the /vehicle/vehicleswitch/ namespace, same as
+getLatestConfig / verifyControlPassword; the /app/push/ paths return 404 on
+dilinkappoversea-eu.byd.auto):
+  - /vehicle/vehicleswitch/getPushSwitchState  (get current state)
+  - /vehicle/vehicleswitch/setPushSwitchState  (toggle on/off)
 """
 
 from __future__ import annotations
@@ -11,11 +13,15 @@ from pybyd._api._common import ENDPOINT_NOT_SUPPORTED_CODES, build_inner_base, p
 from pybyd._transport import Transport
 from pybyd.config import BydConfig
 from pybyd.models.control import CommandAck
-from pybyd.models.push_notification import PushNotificationState
+from pybyd.models.push_notification import (
+    VEHICLE_STATUS_PUSH_TYPE,
+    PushNotificationState,
+    PushSwitch,
+)
 from pybyd.session import Session
 
-_GET_ENDPOINT = "/app/push/getPushSwitchState"
-_SET_ENDPOINT = "/app/push/setPushSwitchState"
+_GET_ENDPOINT = "/vehicle/vehicleswitch/getPushSwitchState"
+_SET_ENDPOINT = "/vehicle/vehicleswitch/setPushSwitchState"
 
 
 async def fetch_push_state(
@@ -41,8 +47,11 @@ async def fetch_push_state(
         vin=vin,
         not_supported_codes=ENDPOINT_NOT_SUPPORTED_CODES,
     )
-    raw = decoded if isinstance(decoded, dict) else {}
-    return PushNotificationState.model_validate({"vin": vin, **raw})
+    raw_list = decoded if isinstance(decoded, list) else []
+    switches = [
+        PushSwitch(type=item.get("type"), state=item.get("state")) for item in raw_list if isinstance(item, dict)
+    ]
+    return PushNotificationState(vin=vin, switches=switches)
 
 
 async def set_push_state(
@@ -52,21 +61,27 @@ async def set_push_state(
     vin: str,
     *,
     enable: bool,
+    push_type: int = VEHICLE_STATUS_PUSH_TYPE,
 ) -> CommandAck:
-    """Set the push notification state for a vehicle.
+    """Enable/disable a per-type push notification switch.
+
+    The EU endpoint is keyed by notification ``type`` (the getPushSwitchState
+    response is a list of ``{type, state}``). NOTE (Sealion 7 EU): this write
+    returns ``code=1001`` ("not supported") for the status-push type — the car
+    does not allow enabling vehicle status push remotely. The body below
+    ({type, state}) mirrors the read keys but is unverified against a
+    successful write.
 
     Parameters
     ----------
     enable : bool
-        True to enable push notifications, False to disable.
-
-    Returns
-    -------
-    CommandAck
-        Decoded API acknowledgement.
+        True to enable, False to disable.
+    push_type : int
+        Notification type code to toggle (default: vehicle status push, 701).
     """
     inner = build_inner_base(config, vin=vin)
-    inner["pushSwitch"] = str(1 if enable else 0)
+    inner["type"] = str(push_type)
+    inner["state"] = str(1 if enable else 0)
     decoded = await post_token_json(
         endpoint=_SET_ENDPOINT,
         config=config,

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -1160,9 +1160,13 @@ class BydClient:
         """Fetch push notification state."""
         return await self._authed_call(_push_api.fetch_push_state, vin)
 
-    async def set_push_state(self, vin: str, *, enable: bool) -> CommandAck:
-        """Enable or disable push notifications."""
-        return await self._authed_call(_push_api.set_push_state, vin, enable=enable)
+    async def set_push_state(self, vin: str, *, enable: bool, push_type: int = 701) -> CommandAck:
+        """Enable/disable a per-type push notification switch.
+
+        Defaults to the vehicle status push (type 701). NOTE: returns
+        code=1001 (not supported) on the Sealion 7 EU.
+        """
+        return await self._authed_call(_push_api.set_push_state, vin, enable=enable, push_type=push_type)
 
     # ------------------------------------------------------------------
     # Control commands

--- a/src/pybyd/models/push_notification.py
+++ b/src/pybyd/models/push_notification.py
@@ -1,16 +1,46 @@
-"""Push notification state model."""
+"""Push notification state model.
+
+The EU endpoint ``/vehicle/vehicleswitch/getPushSwitchState`` returns a LIST of
+per-notification-type switches, e.g. ``[{"state":1,"type":1}, ...]`` — not a
+single boolean. ``type 701`` is the vehicle real-time status push (mirrors the
+``vehicleStatusPushLearnInfo`` capability flag); when ON the cloud is expected
+to relay car-originated status onto the MQTT result topic without a poll.
+"""
 
 from __future__ import annotations
 
 from pybyd.models._base import BydBaseModel
 
+# Notification "type" code for the vehicle real-time status push.
+VEHICLE_STATUS_PUSH_TYPE = 701
+
+
+class PushSwitch(BydBaseModel):
+    """A single per-type push notification switch."""
+
+    type: int | None = None
+    state: int | None = None
+
 
 class PushNotificationState(BydBaseModel):
-    """Push notification switch state for a vehicle."""
+    """Per-type push notification switch states for a vehicle."""
 
     vin: str = ""
-    push_switch: int | None = None
+    switches: list[PushSwitch] = []
+
+    def state_for(self, push_type: int) -> int | None:
+        """Return the on/off state (1/0) for a notification ``type``, or None."""
+        for sw in self.switches:
+            if sw.type == push_type:
+                return sw.state
+        return None
+
+    @property
+    def status_push_enabled(self) -> bool:
+        """Whether the vehicle real-time status push (type 701) is enabled."""
+        return self.state_for(VEHICLE_STATUS_PUSH_TYPE) == 1
 
     @property
     def is_enabled(self) -> bool:
-        return self.push_switch is not None and self.push_switch == 1
+        """Legacy alias — True when the vehicle status push (701) is on."""
+        return self.status_push_enabled

--- a/tests/test_push_switch_eu.py
+++ b/tests/test_push_switch_eu.py
@@ -1,0 +1,76 @@
+"""Tests for the EU push-switch endpoint + per-type list parsing.
+
+The EU host serves push switches under ``/vehicle/vehicleswitch/`` (the
+``/app/push/`` paths 404) and returns a LIST of ``{type, state}`` entries
+rather than a single boolean. ``fetch_push_state`` parses that into
+``PushNotificationState.switches`` with ``state_for`` / ``status_push_enabled``
+helpers (type 701 = vehicle real-time status push).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import pybyd._api.push_notifications as push
+from pybyd._api.push_notifications import _GET_ENDPOINT, fetch_push_state
+from pybyd.models.push_notification import (
+    VEHICLE_STATUS_PUSH_TYPE,
+    PushNotificationState,
+    PushSwitch,
+)
+
+
+def test_endpoint_is_vehicleswitch_namespace() -> None:
+    """The EU path lives under /vehicle/vehicleswitch/, not /app/push/."""
+    assert _GET_ENDPOINT == "/vehicle/vehicleswitch/getPushSwitchState"
+
+
+def test_state_for_and_status_push_enabled() -> None:
+    """Helpers resolve a per-type switch and the 701 status-push flag."""
+    state = PushNotificationState(
+        vin="V",
+        switches=[PushSwitch(type=1, state=0), PushSwitch(type=701, state=1)],
+    )
+    assert state.state_for(701) == 1
+    assert state.state_for(1) == 0
+    assert state.state_for(999) is None
+    assert state.status_push_enabled is True
+    assert VEHICLE_STATUS_PUSH_TYPE == 701
+
+
+def test_status_push_disabled_when_701_off() -> None:
+    state = PushNotificationState(vin="V", switches=[PushSwitch(type=701, state=0)])
+    assert state.status_push_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_parses_eu_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A list response is parsed into per-type switches."""
+    monkeypatch.setattr(push, "build_inner_base", lambda *a, **k: {})
+
+    async def _fake_post(**kwargs: Any) -> Any:
+        return [{"type": 701, "state": 1}, {"type": 1, "state": 0}]
+
+    monkeypatch.setattr(push, "post_token_json", _fake_post)
+
+    result = await fetch_push_state(None, None, None, "VIN")
+    assert result.vin == "VIN"
+    assert result.status_push_enabled is True
+    assert result.state_for(1) == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_handles_non_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-list response degrades to an empty switch set (no crash)."""
+    monkeypatch.setattr(push, "build_inner_base", lambda *a, **k: {})
+
+    async def _fake_post(**kwargs: Any) -> Any:
+        return {"unexpected": "shape"}
+
+    monkeypatch.setattr(push, "post_token_json", _fake_post)
+
+    result = await fetch_push_state(None, None, None, "VIN")
+    assert result.switches == []
+    assert result.status_push_enabled is False


### PR DESCRIPTION
Refs #31.

## Problem

`get/setPushSwitchState` are currently hit at `/app/push/...`, which **404s on the overseas EU host** (`dilinkappoversea-eu.byd.auto`). They actually live under the `/vehicle/vehicleswitch/` namespace (same as `getLatestConfig` / `verifyControlPassword`).

Also, the EU `getPushSwitchState` response is a **list of `{type, state}`** per notification category, not a single `pushSwitch` boolean, so the old single-boolean model never populated.

## Change

- Point both endpoints at `/vehicle/vehicleswitch/{get,set}PushSwitchState`.
- Parse the list into `PushNotificationState.switches` (`PushSwitch{type, state}`) with `state_for(type)` and `status_push_enabled` helpers. `type 701` = vehicle real-time status push (mirrors the `vehicleStatusPushLearnInfo` capability).
- `set_push_state` gains a `push_type` arg (default 701) and sends `{type, state}`.

## Notes / honesty

Read is verified working on EU. **Enabling** the status push (701) via `setPushSwitchState` returns `code=1001` (not supported) on the Sealion 7 EU — documented in the docstring; the write body shape is best-effort and unverified against a successful write (I couldn't get the car to accept it).

## Tests

New `tests/test_push_switch_eu.py`: endpoint namespace, `state_for`/`status_push_enabled`, list parsing in `fetch_push_state`, and graceful handling of a non-list response. Full suite green; ruff / black / mypy clean.