### PR TITLE
feat(mqtt): self-recover on CONNACK refusal (re-login with backoff)

### DIFF
--- a/src/pybyd/_mqtt.py
+++ b/src/pybyd/_mqtt.py
@@ -147,6 +147,7 @@ class BydMqttRuntime:
         decrypt_key_hex: str,
         on_event: Callable[[MqttEvent], None],
         on_decrypt_error: Callable[[], None] | None = None,
+        on_connack_refused: Callable[[int], None] | None = None,
         on_connected: Callable[[], None] | None = None,
         keepalive: int = 120,
         logger: logging.Logger | None = None,
@@ -155,12 +156,16 @@ class BydMqttRuntime:
         self._decrypt_key_hex = decrypt_key_hex
         self._on_event = on_event
         self._on_decrypt_error = on_decrypt_error
+        self._on_connack_refused = on_connack_refused
         self._on_connected = on_connected
         self._keepalive = keepalive
         self._logger = logger or logging.getLogger(__name__)
         self._client: mqtt.Client | None = None
         self._running = False
         self._topic: str | None = None
+        # Count of consecutive refused CONNACKs (paho auto-reconnects reuse
+        # the same stale credentials forever; this drives client recovery).
+        self._consecutive_connack_refusals = 0
 
     @property
     def is_running(self) -> bool:
@@ -201,8 +206,18 @@ class BydMqttRuntime:
             _properties: Any,
         ) -> None:
             if reason_code.value != 0:
-                self._logger.warning("MQTT connect failed reason=%s", reason_code)
+                self._consecutive_connack_refusals += 1
+                n = self._consecutive_connack_refusals
+                self._logger.warning(
+                    "MQTT connect failed reason=%s (consecutive refusals=%d)",
+                    reason_code,
+                    n,
+                )
+                if self._on_connack_refused is not None:
+                    with contextlib.suppress(RuntimeError):
+                        self._loop.call_soon_threadsafe(self._on_connack_refused, n)
                 return
+            self._consecutive_connack_refusals = 0
             self._logger.debug("MQTT connected reason=%s", reason_code)
             if self._topic:
                 self._logger.debug("MQTT subscribe topic=%s", self._topic)

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import functools
 import logging
+import random
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
@@ -141,6 +142,9 @@ class BydClient:
         self._mqtt_runtime: BydMqttRuntime | None = None
         self._mqtt_waiters: list[_MqttWaiter] = []
         self._mqtt_reauth_at: float = 0.0
+        # CONNACK-refusal recovery state (see _on_mqtt_connack_refused).
+        self._mqtt_recovery_attempts: int = 0
+        self._mqtt_recovery_last_at: float = 0.0
         self._on_vehicle_info = on_vehicle_info
         self._on_mqtt_event_cb = on_mqtt_event
         self._on_command_ack_cb = on_command_ack
@@ -444,7 +448,8 @@ class BydClient:
                 decrypt_key_hex=session.content_key(),
                 on_event=self._on_mqtt_event,
                 on_decrypt_error=self._schedule_mqtt_reauth,
-                on_connected=self._on_mqtt_connect_cb,
+                on_connack_refused=self._on_mqtt_connack_refused,
+                on_connected=self._on_mqtt_connected,
                 keepalive=self._config.mqtt_keepalive,
                 logger=_logger,
             )
@@ -469,6 +474,16 @@ class BydClient:
 
     _MQTT_REAUTH_COOLDOWN_S: float = 60.0
 
+    # CONNACK-refusal recovery: when the broker refuses our CONNECT (e.g. the
+    # shared account's MQTT session was taken over by another login), paho
+    # retries the same stale credentials forever. After this many consecutive
+    # refusals, force a re-login to re-derive the session + MQTT password.
+    _MQTT_CONNACK_REFUSAL_THRESHOLD: int = 3
+    _MQTT_RECOVERY_BACKOFF_BASE_S: float = 30.0
+    _MQTT_RECOVERY_BACKOFF_MAX_S: float = 1800.0
+    _MQTT_RECOVERY_BACKOFF_FACTOR: float = 2.0
+    _MQTT_RECOVERY_MAX_ATTEMPTS: int = 6
+
     def _schedule_mqtt_reauth(self) -> None:
         """Schedule a background re-authentication after MQTT decrypt failure.
 
@@ -490,6 +505,69 @@ class BydClient:
             _logger.info("MQTT re-auth succeeded — MQTT restarted with new key")
         except Exception:
             _logger.debug("MQTT re-auth recovery failed", exc_info=True)
+
+    def _on_mqtt_connected(self) -> None:
+        """Handle a genuine successful CONNACK.
+
+        Resets the CONNACK-refusal recovery counters — only a successful
+        connect proves the (possibly re-derived) credentials were accepted,
+        so this is the only place they reset; a re-login that is immediately
+        refused again still counts toward the ceiling and won't loop fast.
+        Then forwards to the caller-supplied cloud-online callback.
+        """
+        if self._mqtt_recovery_attempts:
+            _logger.info("MQTT connected — recovery state reset")
+        self._mqtt_recovery_attempts = 0
+        self._mqtt_recovery_last_at = 0.0
+        if self._on_mqtt_connect_cb is not None:
+            self._on_mqtt_connect_cb()
+
+    def _on_mqtt_connack_refused(self, consecutive: int) -> None:
+        """Drive recovery when the broker refuses our MQTT CONNECT.
+
+        Runs on the asyncio loop (dispatched from the paho thread). After
+        ``_MQTT_CONNACK_REFUSAL_THRESHOLD`` consecutive refusals, force a
+        re-login (re-derives session + getEmqBrokerIp + fresh MQTT password)
+        to reclaim a session another login on the shared account may have
+        taken. Exponential backoff + jitter avoid a login storm / lock-step
+        ping-pong with a second client; a max-attempts ceiling stops the
+        push channel entirely so paho cannot hammer the broker forever.
+        """
+        if consecutive < self._MQTT_CONNACK_REFUSAL_THRESHOLD:
+            return
+        if self._mqtt_recovery_attempts >= self._MQTT_RECOVERY_MAX_ATTEMPTS:
+            _logger.warning(
+                "MQTT recovery ceiling reached (%d attempts) — stopping push " "channel until the next login()",
+                self._mqtt_recovery_attempts,
+            )
+            self._stop_mqtt()
+            return
+        now = time.monotonic()
+        delay = min(
+            self._MQTT_RECOVERY_BACKOFF_BASE_S * (self._MQTT_RECOVERY_BACKOFF_FACTOR**self._mqtt_recovery_attempts),
+            self._MQTT_RECOVERY_BACKOFF_MAX_S,
+        )
+        delay *= random.uniform(0.8, 1.2)  # jitter: break lock-step ping-pong
+        if now - self._mqtt_recovery_last_at < delay:
+            return  # still inside the backoff window
+        self._mqtt_recovery_last_at = now
+        self._mqtt_recovery_attempts += 1
+        _logger.info(
+            "MQTT CONNACK refused x%d — scheduling re-login (attempt %d/%d)",
+            consecutive,
+            self._mqtt_recovery_attempts,
+            self._MQTT_RECOVERY_MAX_ATTEMPTS,
+        )
+        asyncio.ensure_future(self._mqtt_recover_via_login())  # noqa: RUF006
+
+    async def _mqtt_recover_via_login(self) -> None:
+        """Stop the stale MQTT runtime and re-login to reclaim the session."""
+        try:
+            self._stop_mqtt()  # stop paho resending the stale CONNECT first
+            await self.login()  # re-derives session + broker + restarts MQTT
+            _logger.info("MQTT recovery: re-login done, push channel restarted")
+        except Exception:
+            _logger.warning("MQTT recovery re-login failed", exc_info=True)
 
     def _on_mqtt_event(self, event: MqttEvent) -> None:
         """Handle a decrypted MQTT event (called from the MQTT thread via call_soon_threadsafe)."""

--- a/tests/test_mqtt_connack_recovery.py
+++ b/tests/test_mqtt_connack_recovery.py
@@ -1,0 +1,102 @@
+"""Tests for MQTT CONNACK-refusal recovery.
+
+When the broker refuses our CONNECT (e.g. the shared account's MQTT session
+was taken over), paho retries the same stale credentials forever. After
+``_MQTT_CONNACK_REFUSAL_THRESHOLD`` consecutive refusals the client forces a
+re-login, with exponential backoff + jitter and a max-attempts ceiling. Only a
+successful CONNACK resets the counters.
+
+These exercise the decision logic on a bare client (no I/O) with stubs for
+``_stop_mqtt`` / ``_mqtt_recover_via_login``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pybyd.client import BydClient
+
+
+def _bare_client() -> BydClient:
+    client = BydClient.__new__(BydClient)  # no __init__: avoid network/config
+    client._mqtt_recovery_attempts = 0
+    client._mqtt_recovery_last_at = 0.0
+    client._on_mqtt_connect_cb = None
+    client._stop_mqtt = lambda: None  # type: ignore[method-assign]
+    return client
+
+
+def test_below_threshold_does_nothing() -> None:
+    """Fewer than THRESHOLD consecutive refusals must not trigger recovery."""
+    client = _bare_client()
+    for n in range(1, BydClient._MQTT_CONNACK_REFUSAL_THRESHOLD):
+        client._on_mqtt_connack_refused(n)
+    assert client._mqtt_recovery_attempts == 0
+    assert client._mqtt_recovery_last_at == 0.0
+
+
+def test_on_connected_resets_counters_and_forwards_callback() -> None:
+    """A successful CONNACK resets recovery state and forwards the cloud cb."""
+    client = _bare_client()
+    client._mqtt_recovery_attempts = 4
+    client._mqtt_recovery_last_at = 123.0
+    calls: list[bool] = []
+    client._on_mqtt_connect_cb = lambda: calls.append(True)
+
+    client._on_mqtt_connected()
+
+    assert client._mqtt_recovery_attempts == 0
+    assert client._mqtt_recovery_last_at == 0.0
+    assert calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_threshold_schedules_one_relogin() -> None:
+    """Hitting the threshold schedules exactly one re-login and counts it."""
+    client = _bare_client()
+    scheduled: list[bool] = []
+
+    async def _recover() -> None:
+        scheduled.append(True)
+
+    client._mqtt_recover_via_login = _recover  # type: ignore[method-assign]
+
+    client._on_mqtt_connack_refused(BydClient._MQTT_CONNACK_REFUSAL_THRESHOLD)
+
+    assert client._mqtt_recovery_attempts == 1
+    assert client._mqtt_recovery_last_at > 0.0
+    await asyncio.sleep(0)  # let the scheduled task run
+    assert scheduled == [True]
+
+
+@pytest.mark.asyncio
+async def test_backoff_window_blocks_immediate_retry() -> None:
+    """A second refusal inside the backoff window must not re-trigger."""
+    client = _bare_client()
+
+    async def _recover() -> None:
+        return None
+
+    client._mqtt_recover_via_login = _recover  # type: ignore[method-assign]
+
+    client._on_mqtt_connack_refused(BydClient._MQTT_CONNACK_REFUSAL_THRESHOLD)
+    assert client._mqtt_recovery_attempts == 1
+
+    client._on_mqtt_connack_refused(BydClient._MQTT_CONNACK_REFUSAL_THRESHOLD + 1)
+    assert client._mqtt_recovery_attempts == 1  # still inside backoff
+    await asyncio.sleep(0)
+
+
+def test_ceiling_stops_channel() -> None:
+    """At the attempt ceiling, stop the push channel instead of relogging."""
+    client = _bare_client()
+    client._mqtt_recovery_attempts = BydClient._MQTT_RECOVERY_MAX_ATTEMPTS
+    stopped: list[bool] = []
+    client._stop_mqtt = lambda: stopped.append(True)  # type: ignore[method-assign]
+
+    client._on_mqtt_connack_refused(99)
+
+    assert stopped == [True]
+    assert client._mqtt_recovery_attempts == BydClient._MQTT_RECOVERY_MAX_ATTEMPTS


### PR DESCRIPTION
## Problem

When the broker **refuses our CONNECT** (reason_code != 0) — typically because the shared BYD account's MQTT session was taken over by another login (the app, a second HA instance) — paho's auto-reconnect retries the *same stale credentials* forever. The push channel silently stays dead until the process restarts.

## Change

- `BydMqttRuntime` counts **consecutive refused CONNACKs** (reset to 0 on a successful connect) and surfaces them through a new `on_connack_refused(n)` callback. `on_connected` (existing) is unchanged.
- `BydClient` wires it up: after `_MQTT_CONNACK_REFUSAL_THRESHOLD` (3) consecutive refusals it forces a **re-login** (`login()` re-derives session + `getEmqBrokerIp` + a fresh MQTT password and restarts the runtime), reclaiming a session another login may have taken.
- **Exponential backoff** (30 s base × 2, capped 30 min) + **jitter** prevents a login storm and the lock-step ping-pong two clients can get into.
- **Ceiling** of 6 attempts: past that, stop the push channel entirely so paho can't hammer the broker forever (it comes back on the next explicit `login()`).
- Counters reset **only** on a genuine successful CONNACK, so a re-login that's immediately refused still counts toward the ceiling and can't fast-loop.

## Tests

New `tests/test_mqtt_connack_recovery.py`: below-threshold no-op, successful-connect reset + cloud-online callback forwarding, threshold schedules exactly one re-login, backoff window blocks an immediate retry, and the ceiling stops the channel. Full suite green; ruff / black / mypy clean.