### PR TITLE
feat(booking): read scheduled-climate timers via getBookingList

### DIFF
--- a/src/pybyd/_api/booking.py
+++ b/src/pybyd/_api/booking.py
@@ -1,0 +1,41 @@
+"""Booking-list endpoint.
+
+Endpoints:
+  - /control/getBookingList  (read scheduled-climate timers)
+"""
+
+from __future__ import annotations
+
+from pybyd._api._common import ENDPOINT_NOT_SUPPORTED_CODES, build_inner_base, post_token_json
+from pybyd._transport import Transport
+from pybyd.config import BydConfig
+from pybyd.models.booking import BookingList
+from pybyd.session import Session
+
+_ENDPOINT = "/control/getBookingList"
+
+
+async def fetch_booking_list(
+    config: BydConfig,
+    session: Session,
+    transport: Transport,
+    vin: str,
+) -> BookingList:
+    """Fetch the vehicle's scheduled-climate (``BOOKINGAIR``) timers.
+
+    The endpoint occasionally returns an empty object even when a booking
+    exists; an empty :class:`BookingList.bookings` therefore means
+    "none reported", not a guaranteed "no bookings set".
+    """
+    inner = build_inner_base(config, vin=vin)
+    decoded = await post_token_json(
+        endpoint=_ENDPOINT,
+        config=config,
+        session=session,
+        transport=transport,
+        inner=inner,
+        vin=vin,
+        not_supported_codes=ENDPOINT_NOT_SUPPORTED_CODES,
+    )
+    raw = decoded if isinstance(decoded, dict) else {}
+    return BookingList.model_validate({"vin": vin, **raw})

--- a/src/pybyd/client.py
+++ b/src/pybyd/client.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 import aiohttp
 
+from pybyd._api import booking as _booking_api
 from pybyd._api import charging as _charging_api
 from pybyd._api import control as _control_api
 from pybyd._api import energy as _energy_api
@@ -39,6 +40,7 @@ from pybyd.exceptions import (
     BydSessionExpiredError,
 )
 from pybyd.models._base import BydBaseModel
+from pybyd.models.booking import BookingList
 from pybyd.models.charging import ChargingStatus
 from pybyd.models.command_gating import evaluate_command_gate
 from pybyd.models.control import (
@@ -1671,3 +1673,12 @@ class BydClient:
     async def rename_vehicle(self, vin: str, *, name: str) -> CommandAck:
         """Rename a vehicle."""
         return await self._authed_call(_settings_api.rename_vehicle, vin, name=name)
+
+    async def get_booking_list(self, vin: str) -> BookingList:
+        """Fetch the vehicle's scheduled-climate (``BOOKINGAIR``) timers.
+
+        Note: the endpoint intermittently returns an empty payload even when a
+        booking is set, so an empty ``bookings`` list means "none reported",
+        not a guaranteed "none scheduled".
+        """
+        return await self._authed_call(_booking_api.fetch_booking_list, vin)

--- a/src/pybyd/models/__init__.py
+++ b/src/pybyd/models/__init__.py
@@ -2,6 +2,7 @@
 
 from pybyd._constants import VALID_CLIMATE_DURATIONS, minutes_to_time_span
 from pybyd.models._base import BydBaseModel, BydEnum, BydTimestamp, parse_byd_timestamp
+from pybyd.models.booking import BookingList, ClimateBooking
 from pybyd.models.charging import ChargingStatus
 from pybyd.models.command_gating import CommandGateRule, CommandGateVerdict
 from pybyd.models.control import (
@@ -51,7 +52,9 @@ __all__ = [
     "BydEnum",
     "BydTimestamp",
     "ChargingState",
+    "BookingList",
     "ChargingStatus",
+    "ClimateBooking",
     "CommandGateRule",
     "CommandGateVerdict",
     "ClimateScheduleParams",

--- a/src/pybyd/models/booking.py
+++ b/src/pybyd/models/booking.py
@@ -1,0 +1,58 @@
+"""Scheduled-climate booking list model.
+
+``/control/getBookingList`` returns the vehicle's scheduled HVAC timers
+(the ``BOOKINGAIR`` bookings), e.g.::
+
+    {"allowSetting": 0, "configData": 0,
+     "listInfo": [{"bookingTime": 1780938216, "mainSettingTemp": 23,
+                   "mainSettingTempNew": 23.0, "timeSpan": 1, "acSwitch": 0,
+                   "cycleMode": 2, "windLevel": 0, "windMode": 0,
+                   "airConditionTempRange": 7, "bookingId": 1216038691305533440}]}
+
+Note: this endpoint has been observed to return an empty ``{}`` intermittently
+even when a booking is set, so callers should treat an empty list as
+"unknown / try again" rather than "no bookings".
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from pybyd.models._base import BydBaseModel, BydTimestamp
+
+
+class ClimateBooking(BydBaseModel):
+    """A single scheduled-climate timer (one ``listInfo`` entry)."""
+
+    booking_id: int | None = None
+    """Server-assigned booking id (64-bit); required to modify/remove it."""
+    booking_time: BydTimestamp = None
+    """When the climate timer fires (parsed from epoch seconds)."""
+    main_setting_temp: int | None = None
+    """Driver setpoint on BYD's raw scale."""
+    main_setting_temp_new: float | None = None
+    """Driver setpoint in °C."""
+    time_span: int | None = None
+    """Run-duration code: 1=10min, 2=15min, 3=20min, 4=25min, 5=30min."""
+    ac_switch: int | None = None
+    """A/C on (1) / off (0) for the scheduled run."""
+    cycle_mode: int | None = None
+    """Air recirculation: 1=fresh, 2=recirculate."""
+    wind_level: int | None = None
+    wind_mode: int | None = None
+    air_condition_temp_range: int | None = None
+
+
+class BookingList(BydBaseModel):
+    """Scheduled-climate bookings for a vehicle (``getBookingList`` response)."""
+
+    _KEY_ALIASES: ClassVar[dict[str, str]] = {
+        "listInfo": "bookings",
+    }
+
+    vin: str = ""
+    allow_setting: int | None = None
+    config_data: int | None = None
+    bookings: list[ClimateBooking] = Field(default_factory=list)

--- a/tests/test_booking_list.py
+++ b/tests/test_booking_list.py
@@ -1,0 +1,55 @@
+"""Tests for the getBookingList model (scheduled-climate timers).
+
+Payload shape captured live from a Sealion 7 (EU)::
+
+    {"allowSetting": 0, "configData": 0,
+     "listInfo": [{"bookingTime": 1780938216, "mainSettingTemp": 23,
+                   "mainSettingTempNew": 23.0, "timeSpan": 1, "acSwitch": 0,
+                   "cycleMode": 2, "windLevel": 0, "windMode": 0,
+                   "airConditionTempRange": 7, "bookingId": 1216038691305533440}]}
+"""
+
+from __future__ import annotations
+
+from pybyd.models.booking import BookingList
+
+_CAPTURED = {
+    "allowSetting": 0,
+    "configData": 0,
+    "listInfo": [
+        {
+            "bookingTime": 1780938216,
+            "mainSettingTemp": 23,
+            "airConditionTempRange": 7,
+            "cycleMode": 2,
+            "windLevel": 0,
+            "timeSpan": 1,
+            "mainSettingTempNew": 23.0,
+            "acSwitch": 0,
+            "bookingId": 1216038691305533440,
+            "windMode": 0,
+        }
+    ],
+}
+
+
+def test_parses_captured_payload() -> None:
+    bl = BookingList.model_validate({"vin": "TESTVIN", **_CAPTURED})
+    assert bl.vin == "TESTVIN"
+    assert bl.allow_setting == 0
+    assert len(bl.bookings) == 1
+    b = bl.bookings[0]
+    assert b.booking_id == 1216038691305533440  # 64-bit id preserved
+    assert b.main_setting_temp == 23
+    assert b.main_setting_temp_new == 23.0
+    assert b.time_span == 1
+    assert b.ac_switch == 0
+    assert b.cycle_mode == 2
+    assert b.booking_time is not None  # epoch -> datetime
+
+
+def test_empty_payload_yields_no_bookings() -> None:
+    """The endpoint can return {} even when a booking exists; degrade gracefully."""
+    bl = BookingList.model_validate({"vin": "TESTVIN"})
+    assert bl.bookings == []
+    assert bl.allow_setting is None


### PR DESCRIPTION
## What

Adds `BydClient.get_booking_list(vin)` over `/control/getBookingList`, returning the vehicle's scheduled HVAC timers (the `BOOKINGAIR` bookings) as a typed `BookingList` / `ClimateBooking` model.

## Payload (captured live from a Sealion 7, EU)

```jsonc
{"allowSetting": 0, "configData": 0,
 "listInfo": [{"bookingTime": 1780938216, "mainSettingTemp": 23,
               "mainSettingTempNew": 23.0, "timeSpan": 1, "acSwitch": 0,
               "cycleMode": 2, "windLevel": 0, "windMode": 0,
               "airConditionTempRange": 7, "bookingId": 1216038691305533440}]}
```

Mapped fields: `bookingId` (64-bit), `bookingTime` (epoch→datetime), `mainSettingTemp`/`mainSettingTempNew`, `timeSpan` (1=10min…5=30min), `acSwitch`, `cycleMode`, `windLevel`, `windMode`, `airConditionTempRange`.

## Caveat (documented in code)

The endpoint intermittently returns an empty `{}` even when a booking exists, so an empty `bookings` list means "none reported", not a guaranteed "none scheduled". Read-only; no command/PIN needed.

## Tests

New `tests/test_booking_list.py`: parses the captured payload (incl. 64-bit id + epoch→datetime) and degrades gracefully on an empty response. Full suite green; ruff / black / mypy clean.