### PR TITLE
docs(latest_config): correct 1030/1031 — 1031 is one-click shutdown, not pre-conditioning

### DIFF
--- a/src/pybyd/models/latest_config.py
+++ b/src/pybyd/models/latest_config.py
@@ -100,10 +100,12 @@ def registered_latest_config_function_nos() -> frozenset[str]:
             "1003",  # ventilation/heating (parent)
             "1004",  # tire pressure (parent)
             "1014",  # location
-            # 1030 / 1031 advertise the BYD app's "one-tap" feature, which
-            # is a *scheduled* departure pre-conditioning flow (BOOKINGAIR
-            # under the hood), not an instant command. Tracked so they don't
-            # show up as unknown function_nos; no separate capability flag.
+            # 1030 = "one-tap prep" (一键备车): the scheduled departure /
+            # pre-conditioning flow (BOOKINGAIR under the hood); no separate
+            # capability flag. 1031 = "one-click shutdown" (一键熄火): an
+            # instant engine-off command, exposed via the one_click_shutdown
+            # capability above. Listed here so neither shows up as an unknown
+            # function_no. Confirmed distinct on a live Sealion 7 (issue #161).
             "1030",
             "1031",
             "10020001",  # sunroof


### PR DESCRIPTION
## What

The comment in `registered_function_nos()` describes `1030`/`1031` together as a *"scheduled departure pre-conditioning flow (BOOKINGAIR), not an instant command"* with *"no separate capability flag"*. That's wrong on both counts:

- They are **distinct** features.
- `1031` **does** have a capability flag — `one_click_shutdown` is already registered in `FEATURE_REGISTRY` above.

Corrected to:
- **1030** = one-tap prep (一键备车) — the scheduled departure / pre-conditioning flow.
- **1031** = one-click shutdown (一键熄火) — an instant engine-off command, exposed via `one_click_shutdown`.

## Why

Confirmed on a live Sealion 7 via `getLatestConfig` + the Chinese labels in https://github.com/jkaberg/hass-byd-vehicle/issues/161. The old comment was misleading future work on the shutdown command (the closed #42 had the split right).

Comment-only change; no behavioral impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)