### PR TITLE
fix(hvac): resolve the placeholder's sensor fields to None instead of surfacing its zeros

### DIFF
--- a/src/pybyd/_validators.py
+++ b/src/pybyd/_validators.py
@@ -281,18 +281,27 @@ def apply_hvac_filters(
 ) -> HvacStatus:
     """Drop the all-zero-sensor placeholder HVAC payload.
 
-    BYD's HVAC HTTP endpoint occasionally returns a payload where every
+    BYD's HVAC HTTP endpoint returns a payload where every
     sensor-population field (``temp_in_car``, ``temp_out_car``, ``pm``)
-    reads 0 simultaneously — a placeholder, not real data.  When detected,
-    pin those three fields to their previous values.  Setpoints / state
-    enums on the same payload still update.
+    reads 0 simultaneously whenever the vehicle's HVAC block is asleep —
+    a placeholder, not real data.  When detected, each of those three
+    fields is pinned to its previous value when one exists, and cleared
+    to ``None`` otherwise — the placeholder's literal 0 must never
+    surface.  Setpoints / state enums on the same payload still update.
+
+    On first poll (``previous is None``) the placeholder is rejected
+    wholesale and the sensor fields resolve to ``None``, matching the
+    realtime zero-drop family's first-poll behaviour.  This matters in
+    practice: a parked car's HVAC block sleeps within minutes, so the
+    first poll after a consumer restart almost always lands on the
+    placeholder — accepting it surfaced a false ``0`` reading, which
+    then self-perpetuated as the pinned "previous value".
 
     A genuine 0 °C reading on one of the sensors round-trips intact as
     long as the same payload carries any other real sensor value (which
-    real payloads always do).
+    real payloads always do), and a genuine 0 already pinned from such
+    a payload keeps being pinned.
     """
-    if previous is None:
-        return incoming
     all_zero_or_missing = all(
         getattr(incoming, field, None) in (None, 0, 0.0) for field in _HVAC_SENSOR_PLACEHOLDER_FIELDS
     )
@@ -300,8 +309,8 @@ def apply_hvac_filters(
         return incoming
     updates: dict[str, Any] = {}
     for field in _HVAC_SENSOR_PLACEHOLDER_FIELDS:
-        prev_value = getattr(previous, field, None)
-        if prev_value is not None:
+        prev_value = getattr(previous, field, None) if previous is not None else None
+        if getattr(incoming, field, None) != prev_value:
             updates[field] = prev_value
     if not updates:
         return incoming

--- a/src/pybyd/_validators.py
+++ b/src/pybyd/_validators.py
@@ -284,37 +284,34 @@ def apply_hvac_filters(
     BYD's HVAC HTTP endpoint has been observed returning a payload where
     every sensor-population field (``temp_in_car``, ``temp_out_car``,
     ``pm``) is 0 or missing simultaneously while the vehicle's HVAC
-    block is asleep — a placeholder, not real data.  When detected, each
-    of those three fields is pinned to its previous value when one
-    exists, and cleared to ``None`` otherwise, so the placeholder's
-    literal 0 does not surface as a reading.  Setpoints / state enums on
-    the same payload still update.
+    block is asleep — a placeholder, not real data.  When detected, all
+    three fields are cleared to ``None`` so the placeholder's literal 0
+    does not surface as a reading: a poll carrying no live sensor data
+    yields no sensor values.  Setpoints / state enums on the same
+    payload still update.
 
-    On first poll (``previous is None``) the placeholder is rejected
-    wholesale and the sensor fields resolve to ``None``, matching the
-    realtime zero-drop family's first-poll behaviour.  This matters in
-    practice: a parked car's HVAC block sleeps within minutes, so a
-    first poll after a consumer restart commonly lands on the
-    placeholder — accepting it surfaced a false ``0`` reading, which
-    then self-perpetuated as the pinned "previous value".
+    Previous values are deliberately NOT pinned over the placeholder
+    (unlike the realtime zero-drop family): the quantities here —
+    temperatures, particulates — keep changing while the vehicle
+    sleeps, so a reading pinned across a multi-hour sleep looks live
+    while being hours old.  ``previous`` stays in the signature for the
+    state-engine call site.
 
     A genuine 0 °C reading on one of the sensors round-trips intact as
     long as the same payload carries any other real sensor value (true
-    of every real capture observed so far), and a genuine 0 already
-    pinned from such a payload keeps being pinned.  The trade-off: a
-    payload whose whole triad is genuinely 0-or-missing at once is
-    indistinguishable from the placeholder and is suppressed too.
+    of every real capture observed so far).  The trade-off: a payload
+    whose whole triad is genuinely 0-or-missing at once is
+    indistinguishable from the placeholder and resolves to ``None``
+    until the next mixed payload.
     """
     all_zero_or_missing = all(
         getattr(incoming, field, None) in (None, 0, 0.0) for field in _HVAC_SENSOR_PLACEHOLDER_FIELDS
     )
     if not all_zero_or_missing:
         return incoming
-    updates: dict[str, Any] = {}
-    for field in _HVAC_SENSOR_PLACEHOLDER_FIELDS:
-        prev_value = getattr(previous, field, None) if previous is not None else None
-        if getattr(incoming, field, None) != prev_value:
-            updates[field] = prev_value
+    updates: dict[str, Any] = {
+        field: None for field in _HVAC_SENSOR_PLACEHOLDER_FIELDS if getattr(incoming, field, None) is not None
+    }
     if not updates:
         return incoming
     return incoming.model_copy(update=updates)

--- a/src/pybyd/_validators.py
+++ b/src/pybyd/_validators.py
@@ -279,28 +279,31 @@ def apply_hvac_filters(
     previous: HvacStatus | None,
     incoming: HvacStatus,
 ) -> HvacStatus:
-    """Drop the all-zero-sensor placeholder HVAC payload.
+    """Drop the all-zero-or-missing placeholder HVAC payload.
 
-    BYD's HVAC HTTP endpoint returns a payload where every
-    sensor-population field (``temp_in_car``, ``temp_out_car``, ``pm``)
-    reads 0 simultaneously whenever the vehicle's HVAC block is asleep —
-    a placeholder, not real data.  When detected, each of those three
-    fields is pinned to its previous value when one exists, and cleared
-    to ``None`` otherwise — the placeholder's literal 0 must never
-    surface.  Setpoints / state enums on the same payload still update.
+    BYD's HVAC HTTP endpoint has been observed returning a payload where
+    every sensor-population field (``temp_in_car``, ``temp_out_car``,
+    ``pm``) is 0 or missing simultaneously while the vehicle's HVAC
+    block is asleep — a placeholder, not real data.  When detected, each
+    of those three fields is pinned to its previous value when one
+    exists, and cleared to ``None`` otherwise, so the placeholder's
+    literal 0 does not surface as a reading.  Setpoints / state enums on
+    the same payload still update.
 
     On first poll (``previous is None``) the placeholder is rejected
     wholesale and the sensor fields resolve to ``None``, matching the
     realtime zero-drop family's first-poll behaviour.  This matters in
-    practice: a parked car's HVAC block sleeps within minutes, so the
-    first poll after a consumer restart almost always lands on the
+    practice: a parked car's HVAC block sleeps within minutes, so a
+    first poll after a consumer restart commonly lands on the
     placeholder — accepting it surfaced a false ``0`` reading, which
     then self-perpetuated as the pinned "previous value".
 
     A genuine 0 °C reading on one of the sensors round-trips intact as
-    long as the same payload carries any other real sensor value (which
-    real payloads always do), and a genuine 0 already pinned from such
-    a payload keeps being pinned.
+    long as the same payload carries any other real sensor value (true
+    of every real capture observed so far), and a genuine 0 already
+    pinned from such a payload keeps being pinned.  The trade-off: a
+    payload whose whole triad is genuinely 0-or-missing at once is
+    indistinguishable from the placeholder and is suppressed too.
     """
     all_zero_or_missing = all(
         getattr(incoming, field, None) in (None, 0, 0.0) for field in _HVAC_SENSOR_PLACEHOLDER_FIELDS

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -867,20 +867,24 @@ class TestHvacPlaceholderFilter:
         assert filtered.temp_out_car is None
         assert filtered.pm is None
 
-    def test_placeholder_pins_previous_real_values(self) -> None:
+    def test_placeholder_clears_fields_despite_previous_real_values(self) -> None:
+        # Previous real readings are NOT pinned over the placeholder:
+        # temperatures and particulates keep changing while the car
+        # sleeps, so a pinned reading goes stale while looking live.
+        # A poll with no live sensor data yields no sensor values.
         previous = HvacStatus.model_validate({"tempInCar": 22.0, "tempOutCar": 14.0, "pm": 8.0})
         incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)
 
         filtered = apply_hvac_filters(previous, incoming)
 
-        assert filtered.temp_in_car == 22.0
-        assert filtered.temp_out_car == 14.0
-        assert filtered.pm == 8.0
+        assert filtered.temp_in_car is None
+        assert filtered.temp_out_car is None
+        assert filtered.pm is None
 
     def test_placeholder_does_not_resurface_zero_over_none_previous(self) -> None:
         # previous.temp_in_car is None (a -129 sentinel was normalised
-        # away); the placeholder's literal 0 must resolve to None, not
-        # leak through because there is no previous value to pin.
+        # away); the placeholder's literal 0 must resolve to None, and
+        # the remaining fields clear alongside it.
         previous = HvacStatus.model_validate({"tempInCar": -129, "tempOutCar": 14.0, "pm": 8.0})
         assert previous.temp_in_car is None
         incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)
@@ -888,8 +892,8 @@ class TestHvacPlaceholderFilter:
         filtered = apply_hvac_filters(previous, incoming)
 
         assert filtered.temp_in_car is None
-        assert filtered.temp_out_car == 14.0
-        assert filtered.pm == 8.0
+        assert filtered.temp_out_car is None
+        assert filtered.pm is None
 
     def test_placeholder_chain_stays_none_after_first_poll_rejection(self) -> None:
         # Two consecutive placeholders from a cold start: the second one
@@ -926,20 +930,21 @@ class TestHvacPlaceholderFilter:
         assert filtered.temp_out_car == 0
         assert filtered.pm == 2.0
 
-    def test_genuine_zero_previous_still_pinned(self) -> None:
-        # A genuine 0 accepted earlier from a mixed payload keeps being
-        # pinned over later placeholders.
+    def test_genuine_zero_previous_clears_on_placeholder(self) -> None:
+        # A genuine 0 accepted earlier from a mixed payload clears like
+        # any other previous reading when a placeholder arrives — the
+        # policy is uniform: no live data in the poll, no sensor value.
         previous = HvacStatus.model_validate({"tempInCar": 5.0, "tempOutCar": 0, "pm": 3.0})
         incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)
 
         filtered = apply_hvac_filters(previous, incoming)
 
-        assert filtered.temp_in_car == 5.0
-        assert filtered.temp_out_car == 0
-        assert filtered.pm == 3.0
+        assert filtered.temp_in_car is None
+        assert filtered.temp_out_car is None
+        assert filtered.pm is None
 
     def test_placeholder_still_updates_non_sensor_fields(self) -> None:
-        # Only the sensor-population fields are pinned; setpoints and
+        # Only the sensor-population fields are cleared; setpoints and
         # state enums on the placeholder payload still update.
         previous = HvacStatus.model_validate(
             {"tempInCar": 22.0, "tempOutCar": 14.0, "pm": 8.0, "mainSettingTemp": 24.0}
@@ -948,5 +953,5 @@ class TestHvacPlaceholderFilter:
 
         filtered = apply_hvac_filters(previous, incoming)
 
-        assert filtered.temp_out_car == 14.0
+        assert filtered.temp_out_car is None
         assert filtered.main_setting_temp == 0.0

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -842,6 +842,31 @@ class TestHvacPlaceholderFilter:
         assert filtered.temp_out_car is None
         assert filtered.pm is None
 
+    def test_first_poll_sentinel_and_zero_placeholder_drops_fields(self) -> None:
+        # The exact wire shape captured from an affected vehicle: tempInCar
+        # arrives as the -129 sentinel (normalised to None by the model)
+        # while tempOutCar and pm are literal 0. The all-zero-OR-MISSING
+        # triad must be rejected wholesale on first poll too — this guards
+        # the sentinel-normalisation → placeholder-filter interaction.
+        incoming = HvacStatus.model_validate(
+            {
+                "tempInCar": -129,
+                "tempOutCar": 0,
+                "pm": 0,
+                "acSwitch": 0,
+                "status": 0,
+                "mainSettingTemp": 0.0,
+                "refrigeratorState": -1,
+            }
+        )
+        assert incoming.temp_in_car is None
+
+        filtered = apply_hvac_filters(None, incoming)
+
+        assert filtered.temp_in_car is None
+        assert filtered.temp_out_car is None
+        assert filtered.pm is None
+
     def test_placeholder_pins_previous_real_values(self) -> None:
         previous = HvacStatus.model_validate({"tempInCar": 22.0, "tempOutCar": 14.0, "pm": 8.0})
         incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -889,6 +889,18 @@ class TestHvacPlaceholderFilter:
         assert filtered.temp_out_car == 0
         assert filtered.pm == 3.0
 
+    def test_first_poll_genuine_winter_zero_passes_through(self) -> None:
+        # Cold-boot consumer on a winter day: exterior genuinely 0 °C but
+        # the payload carries other real sensor values, so it is not a
+        # placeholder — no over-suppression on first poll.
+        incoming = HvacStatus.model_validate({"tempInCar": 0.5, "tempOutCar": 0, "pm": 2.0})
+
+        filtered = apply_hvac_filters(None, incoming)
+
+        assert filtered.temp_in_car == 0.5
+        assert filtered.temp_out_car == 0
+        assert filtered.pm == 2.0
+
     def test_genuine_zero_previous_still_pinned(self) -> None:
         # A genuine 0 accepted earlier from a mixed payload keeps being
         # pinned over later placeholders.

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,10 +7,12 @@ import pytest
 from pybyd._validators import (
     _has_valid_coordinates,
     apply_gps_filters,
+    apply_hvac_filters,
     apply_realtime_filters,
     guard_gps_coordinates,
 )
 from pybyd.models.gps import GpsInfo
+from pybyd.models.hvac import HvacStatus
 from pybyd.models.realtime import LockState, TirePressureUnit, VehicleRealtimeData
 from pybyd.models.vehicle import EnergyType
 
@@ -805,3 +807,109 @@ class TestEnergyConsumptionParsing:
         assert m.nearest_energy_consumption is None
         assert m.auto_model_graph is None
         assert m.timestamp is None
+
+
+# ---------------------------------------------------------------------------
+# HVAC placeholder filter
+# ---------------------------------------------------------------------------
+
+# The asleep-HVAC placeholder as observed on the wire: every
+# sensor-population field literal 0, setpoints 0, state enums inert.
+_HVAC_PLACEHOLDER_RAW = {
+    "tempInCar": 0,
+    "tempOutCar": 0,
+    "pm": 0,
+    "acSwitch": 0,
+    "status": 0,
+    "mainSettingTemp": 0.0,
+    "refrigeratorState": -1,
+}
+
+
+class TestHvacPlaceholderFilter:
+    """apply_hvac_filters: the all-zero sensor placeholder must never surface."""
+
+    def test_first_poll_placeholder_drops_sensor_fields(self) -> None:
+        # A parked car's HVAC block sleeps within minutes, so the first
+        # poll after a consumer restart almost always lands on the
+        # placeholder. It must be rejected wholesale (like the realtime
+        # zero-drop family), not accepted as a baseline of literal 0s.
+        incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)
+
+        filtered = apply_hvac_filters(None, incoming)
+
+        assert filtered.temp_in_car is None
+        assert filtered.temp_out_car is None
+        assert filtered.pm is None
+
+    def test_placeholder_pins_previous_real_values(self) -> None:
+        previous = HvacStatus.model_validate({"tempInCar": 22.0, "tempOutCar": 14.0, "pm": 8.0})
+        incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)
+
+        filtered = apply_hvac_filters(previous, incoming)
+
+        assert filtered.temp_in_car == 22.0
+        assert filtered.temp_out_car == 14.0
+        assert filtered.pm == 8.0
+
+    def test_placeholder_does_not_resurface_zero_over_none_previous(self) -> None:
+        # previous.temp_in_car is None (a -129 sentinel was normalised
+        # away); the placeholder's literal 0 must resolve to None, not
+        # leak through because there is no previous value to pin.
+        previous = HvacStatus.model_validate({"tempInCar": -129, "tempOutCar": 14.0, "pm": 8.0})
+        assert previous.temp_in_car is None
+        incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)
+
+        filtered = apply_hvac_filters(previous, incoming)
+
+        assert filtered.temp_in_car is None
+        assert filtered.temp_out_car == 14.0
+        assert filtered.pm == 8.0
+
+    def test_placeholder_chain_stays_none_after_first_poll_rejection(self) -> None:
+        # Two consecutive placeholders from a cold start: the second one
+        # must not resurface 0 just because the (rejected) first left all
+        # sensor fields at None.
+        first = apply_hvac_filters(None, HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW))
+        second = apply_hvac_filters(first, HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW))
+
+        assert second.temp_in_car is None
+        assert second.temp_out_car is None
+        assert second.pm is None
+
+    def test_mixed_payload_passes_through(self) -> None:
+        # A payload carrying any real sensor value is not a placeholder:
+        # a genuine 0 °C winter reading on one sensor round-trips intact.
+        previous = HvacStatus.model_validate({"tempInCar": 22.0, "tempOutCar": 14.0, "pm": 8.0})
+        incoming = HvacStatus.model_validate({"tempInCar": 5.0, "tempOutCar": 0, "pm": 3.0})
+
+        filtered = apply_hvac_filters(previous, incoming)
+
+        assert filtered.temp_in_car == 5.0
+        assert filtered.temp_out_car == 0
+        assert filtered.pm == 3.0
+
+    def test_genuine_zero_previous_still_pinned(self) -> None:
+        # A genuine 0 accepted earlier from a mixed payload keeps being
+        # pinned over later placeholders.
+        previous = HvacStatus.model_validate({"tempInCar": 5.0, "tempOutCar": 0, "pm": 3.0})
+        incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)
+
+        filtered = apply_hvac_filters(previous, incoming)
+
+        assert filtered.temp_in_car == 5.0
+        assert filtered.temp_out_car == 0
+        assert filtered.pm == 3.0
+
+    def test_placeholder_still_updates_non_sensor_fields(self) -> None:
+        # Only the sensor-population fields are pinned; setpoints and
+        # state enums on the placeholder payload still update.
+        previous = HvacStatus.model_validate(
+            {"tempInCar": 22.0, "tempOutCar": 14.0, "pm": 8.0, "mainSettingTemp": 24.0}
+        )
+        incoming = HvacStatus.model_validate(_HVAC_PLACEHOLDER_RAW)
+
+        filtered = apply_hvac_filters(previous, incoming)
+
+        assert filtered.temp_out_car == 14.0
+        assert filtered.main_setting_temp == 0.0


### PR DESCRIPTION
## What

`apply_hvac_filters` detects the placeholder HVAC payload (every sensor-population field 0 or missing, setpoints 0, `status`/`acSwitch` resolving to UNKNOWN, `refrigeratorState=-1`) but lets its literal 0 through in two cases:

1. First poll of a client session (`previous is None`): the placeholder is accepted wholesale and `temp_out_car` surfaces as a false 0 °C. A parked car's HVAC block sleeps within minutes and consumers poll sparsely, so a first poll after a consumer restart lands on the placeholder more often than not. On the vehicle below, all eight restarts in a week did.
2. Detected placeholder fields whose previous value is None (e.g. `temp_in_car` normalised away from a -129 sentinel) keep the incoming literal 0. The leaked 0 then becomes the pinned "previous value" for every later placeholder.

This is the `temp_out_car` follow-up from [hass-byd-vehicle #142](https://github.com/jkaberg/hass-byd-vehicle/pull/142#issuecomment-5016220305): tempOutCar arrives as a literal 0, not the -129 sentinel.

## Relationship to #49

The guard itself comes from #49 (@peter-dolkens); its code landed on main as `b9b7e4b`. This PR changes three things:

1. #49 documents first-poll passthrough as intended ("first poll with all-zero sensors passes through unchanged... guarded once a real reading establishes one"), and [its discussion](https://github.com/jkaberg/pyBYD/pull/49#issuecomment-4519003409) estimated the corner as "at most one 1-min spike". On a sparse-poll consumer the next real poll is hours to days away, and the accepted 0 also becomes the pinned baseline. The recorder evidence below shows this corner was the dominant leak, so this PR flips that behaviour.
2. #49's tests never landed on main, leaving `apply_hvac_filters` untested there. The tests here restore that coverage (mixed-payload passthrough, genuine-zero round-trip, sentinel mapping) and add the first-poll cases, inverting `test_placeholder_without_previous_passes_through` per the evidence.
3. #49 pins the last real reading over later placeholders; this PR clears the fields to None instead. Reasons under "Open question" below, and the pin-retaining variant is one commit back on the branch (`c8a23c5`) if that policy is preferred.

## Fix

Detection is unchanged. On a detected placeholder, all three sensor-population fields now resolve to None regardless of previous state: a poll carrying no live sensor data yields no sensor values. Setpoints / state enums on the same payload still update.

Genuine readings:

- A genuine 0 °C alongside any other real sensor value in the same payload is not classified as placeholder and passes through unchanged. Every real capture observed so far carries at least one other value; locked in by `test_first_poll_genuine_winter_zero_passes_through`.
- A genuine 0 stored earlier clears like any other previous reading when a placeholder arrives, and comes back on the next mixed payload.

## Open question: clearing vs pinning

The first version of this PR kept #49's pinning (previous value when one exists, None only when there is none). I switched to clearing after running the pinning variant live. Pinning suits car-state values like SoC or tire pressure, which hold still while the car sleeps. The HVAC sensors measure the environment - exterior temperature keeps changing whether the car reports it or not. On my install the car last reported 19 °C in the evening and the sensor held 19 all night, which looks like a live reading but is a 12 hour old sample. Clearing shows unknown for those hours instead, which matches what the API actually delivered. If you'd rather keep pinning, `c8a23c5` is that variant and I'll re-point the PR at it. A staleness bound (pin for N minutes, then clear) would need a last-real timestamp in the state engine, so I left it out of a minimal fix either way.

## Evidence

Seal 6 DM-i (2026 EU/Ireland), Home Assistant 2026.7.2 (NixOS Core install), hass-byd-vehicle 0.0.84, pybyd 0.0.73. The raw placeholder capture from this VIN (redacted; tempInCar=-129, tempOutCar=0, inert HVAC block) is in [the #142 comment](https://github.com/jkaberg/hass-byd-vehicle/pull/142#issuecomment-5016220305); the new first-poll fixture mirrors that wire shape.

Recorder history of the exterior temperature sensor against HA's `recorder_runs` restart timeline (UTC):

```
restart 2026-07-17 21:30:01 -> exterior 0 written 21:30:08  (+7 s; was 19 °C at 20:19)
restart 2026-07-17 21:45:22 -> exterior 0 written 21:45:27  (+5 s)
restart 2026-07-19 17:21:36 -> exterior 0 written 17:21:40  (+4 s; was 20 °C at 16:46)
restart 2026-07-21 07:04:13 -> exterior 0 written 07:04:20  (+7 s)
restart 2026-07-21 07:11:07 -> exterior 0 written 07:11:14  (+7 s)
restart 2026-07-21 13:33:01 -> exterior 0 written 13:33:08  (+7 s)
restart 2026-07-23 13:50:37 -> exterior 0 written 13:50:44  (+7 s)
restart 2026-07-23 16:39:37 -> exterior 0 written 16:39:43  (+6 s)
```

Every false-0 state change in the week lands 4-7 s after a restart, i.e. the first poll. Real values (19-20 °C, matching Dublin July ambient) appear only mid-session when a poll caught the car awake.

Post-patch startup journal (VIN redacted):

```
22:29:07 INFO [homeassistant.setup] Setting up byd_vehicle
22:29:08 INFO [pybyd.client] Command access verified for VIN LC0…3420
22:29:11 INFO [custom_components.byd_vehicle.coordinator] fetch_charging result: vin=…3420, … soc=40 …
22:29:11 INFO [homeassistant.components.sensor] Setting up byd_vehicle.sensor
```

## End-to-end test

1. Build pybyd 0.0.73 with this diff applied; restart Home Assistant with the car parked and asleep (the placeholder condition, per the table above).
2. After the integration's first refresh, read `/api/states` for `..._exterior_temperature` and `..._pm2_5`.

Before: both report 0 / 0.0 within 4-7 s of startup (all eight restarts above). After: both report `unknown`, held across three consecutive post-patch restarts the same evening (first-poll behaviour is identical in the pinning and clearing variants). Running the pinning variant, the next awake poll delivered a real 19 °C which then stayed pinned across every placeholder overnight; that sample is what prompted the switch to clearing. My install runs the clearing variant now.

## Limitations

- Detection keys on the all-zero-or-missing triad. A payload whose whole triad is genuinely 0-or-missing at once (cabin sentinel-missing, exterior genuinely 0 °C, PM2.5 exactly 0.0) is indistinguishable from the placeholder and gets suppressed too. No such capture has been observed; the pre-fix code misclassified it as well, and the post-fix worst case is `unknown` until the next mixed payload rather than a value indistinguishable from the bug.
- Clearing trades continuity for freshness: a short placeholder blip while the vehicle is awake flaps real -> unknown -> real instead of holding, and consumer history shows gaps across sleeps. `.raw` keeps the wire payload throughout.
- The placeholder's `mainSettingTemp=0.0` and `status`/`acSwitch` UNKNOWN still update the model; only the three sensor fields are cleared. Checked against hass-byd-vehicle: its climate target uses `main_setting_temp_new` (absent in the placeholder) and maps status UNKNOWN to off.

An alternative gate on HVAC-block liveness (status in ON/OFF, setpoints nonzero; floated in the #142 discussion) was rejected: the only confirmed real readings on this VIN come from an awake-but-parked, climate-off car, and no capture proves that state reports status ON/OFF. If it reports UNKNOWN, a liveness gate would suppress the only genuine readings the endpoint delivers.

## Validation

- 199 tests pass; 9 new or updated (first-poll rejection including the captured sentinel+zero wire shape, clear-despite-previous, no-resurface-over-None, placeholder chains, mixed-payload passthrough, winter first-poll passthrough, genuine-zero handling, non-sensor-field updates)
- `ruff check .`, `black --check .`, `mypy` pass

Disclosure: diagnosis and patch were AI-assisted. The captures and recorder evidence are from my own vehicle and installation, and the behaviour reproduces with the steps above.