### PR TITLE
docs(models): clarify energy fields are consumption rates, not absolute kWh

### DIFF
--- a/src/pybyd/models/energy.py
+++ b/src/pybyd/models/energy.py
@@ -81,7 +81,11 @@ class EnergyConsumptionGraph(BydBaseModel):
 
 
 class CumulativeEnergyConsumption(BydBaseModel):
-    """Lifetime cumulative consumption, per leg.
+    """Lifetime AVERAGE consumption rate, per leg.
+
+    Named ``cumulativeEnergyConsumption`` by the API, but the fields it
+    carries are consumption rates (kWh/100km, L/100km) averaged over
+    the vehicle's lifetime — not an absolute cumulative energy total.
 
     Both legs are populated for hybrids when ``powerType="2"``; pure-EV
     or pure-ICE responses leave the unused leg empty.

--- a/src/pybyd/models/realtime.py
+++ b/src/pybyd/models/realtime.py
@@ -533,15 +533,28 @@ class VehicleRealtimeData(BydBaseModel):
 
     # --- Energy consumption ---
     total_power: float | None = None
+    """Unmapped — semantics unconfirmed. Seen ``0.0`` while parked;
+    not yet observed non-zero. Do NOT assume this is a cumulative
+    energy counter without live confirmation (none of the fields on
+    this endpoint expose absolute lifetime kWh — see the note below)."""
     gl: float | None = None
     """Instantaneous battery power (W)."""
     total_energy: str | None = None
-    """Total energy (string; "--" when unavailable)."""
+    """Lifetime AVERAGE EV consumption rate, kWh/100km (string; "--"
+    when unavailable) — despite the name, this is **not** an absolute
+    energy total. Split into :attr:`total_energy_ev`/:attr:`total_energy_fuel`
+    by :func:`_split_hybrid_legs`, both in kWh/100km (or L/100km for the
+    fuel leg)."""
     nearest_energy_consumption: str | None = None
     """Nearest energy consumption (string; "--" when unavailable)."""
     nearest_energy_consumption_unit: str | None = None
     recent_50km_energy: str | None = None
-    """Recent 50 km energy (string; "--" when unavailable)."""
+    """AVERAGE EV consumption rate over the last 50km, kWh/100km
+    (string; "--" when unavailable) — **not** the absolute energy used
+    over that window. For the actual kWh figure, see
+    ``EnergyConsumption.nearest_energy_consumption.ev_consumption``
+    from the ``getEnergyConsumption`` endpoint (a rolling last-50km
+    window, not aligned to a specific trip)."""
 
     # --- Fuel (hybrid vehicles) ---
     oil_endurance: float | None = None
@@ -602,12 +615,21 @@ class VehicleRealtimeData(BydBaseModel):
     """Time-to-full is less than one minute."""
 
     # --- Energy (extended) ---
+    # NOTE: every field in this section is a CONSUMPTION RATE (kWh/100km,
+    # or L/100km for the fuel leg) despite names like "energy"/"total" that
+    # read as an absolute amount. None of them accumulate — the closest
+    # thing to an absolute-kWh figure on this vehicle is
+    # ``EnergyConsumption.nearest_energy_consumption.ev_consumption`` from
+    # the separate ``getEnergyConsumption`` endpoint (a rolling last-50km
+    # window, not a lifetime or per-trip total).
     energy_consumption: str | None = None
-    """Energy consumption value (string, differs from nearestEnergyConsumption)."""
+    """Recent EV consumption rate, kWh/100km (string; differs from
+    ``nearestEnergyConsumption`` in refresh cadence, not in unit)."""
     total_consumption: str | None = None
-    """Chinese-locale total consumption label."""
+    """Chinese-locale lifetime average consumption rate, kWh/100km."""
     total_consumption_en: str | None = None
-    """English-locale total consumption label (e.g. '16.6kW·h/100km')."""
+    """English-locale lifetime average consumption rate, kWh/100km
+    (e.g. '16.6kW·h/100km')."""
 
     # --- Hybrid leg breakouts (parsed from combined strings) ---
     # For each combined-form field, ``_split_hybrid_legs`` populates four
@@ -615,6 +637,9 @@ class VehicleRealtimeData(BydBaseModel):
     # The original (non-suffixed) field is also rebound to the EV-portion
     # string of the original payload as a backwards-compat alias — the raw
     # combined string remains accessible via ``raw``.
+    #
+    # All *_ev fields below are consumption RATES (kWh/100km), not
+    # absolute energy, same caveat as their un-suffixed source field above.
     energy_consumption_ev: float | None = None
     energy_consumption_ev_unit: str | None = None
     energy_consumption_fuel: float | None = None


### PR DESCRIPTION
While digging into jkaberg/hass-byd-vehicle#115 (looking for a way to cross-check per-trip energy against BYD's own numbers), we nearly mis-mapped `total_energy` and `recent_50km_energy` as absolute kWh — the names read that way, but both are consumption **rates** (kWh/100km), confirmed against live data (`recent50kmEnergy` == `last_50km_average_ev_consumption`, a known rate sensor).

Same ambiguity exists on `energy_consumption`, `total_consumption`/`total_consumption_en`, and `CumulativeEnergyConsumption` (the `getEnergyConsumption` endpoint's "cumulative" section, which is actually a lifetime *average* rate, not a running total).

This PR only touches docstrings/comments — no behavior change:
- `models/realtime.py`: clarified `total_energy`, `recent_50km_energy`, `energy_consumption`, `total_consumption`, `total_consumption_en`, and the per-leg `*_ev`/`*_fuel` split fields all carry rates, not absolute energy. Also flagged `total_power` as unmapped/unconfirmed (currently has zero docs) so it isn't mistaken for the missing counter either.
- `models/energy.py`: clarified `CumulativeEnergyConsumption`'s class docstring — it's a lifetime average rate per leg, not a cumulative kWh total.

Net finding from that investigation, for context: neither the realtime endpoint nor `getEnergyConsumption` exposes an absolute, monotonically-increasing energy counter anywhere today. The closest thing is `NearestEnergyConsumption.ev_consumption` (genuine kWh, but a rolling last-50km window, not trip-aligned).

Ran the full suite locally (py3.12 venv): `190 passed`. ruff/black/mypy clean.